### PR TITLE
feat: Implémentation bouton retour natif iOS avec geste liquid

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,16 @@ Vous pouvez ouvrir l'app dans :
 
 ```
 app/
-  _layout.tsx                 # 🎯 LAYOUT RACINE UNIQUE (Tabs Navigator)
+  _layout.tsx                 # 🎯 LAYOUT RACINE (Stack avec header natif)
   index.tsx                   # Point d'entrée avec persistance
-  (main)/                     # Groupe principal (PAS de _layout.tsx)
-    home.tsx                  # Page d'accueil
-    tp1-profile-card.tsx      # Écran du TP1 (intégré à la navigation)
+  (main)/                     # Groupe principal avec Stack Navigator
+    _layout.tsx               # Stack avec bouton retour natif iOS
+    (tabs)/                   # Groupe onglets
+      _layout.tsx             # Tabs Navigator (Accueil + Profil)
+      home.tsx                # Page d'accueil
+      tp1-profile-card.tsx    # Écran du TP1 (intégré à la navigation)
     detail/
-      [id].tsx                # Écran dynamique avec validation paramètres
+      [id].tsx                # Écran dynamique avec bouton retour natif
   (auth)/                     # Groupe authentification (PAS de _layout.tsx)
     login.tsx                 # Écran de connexion (préparé pour l'avenir)
     register.tsx              # Écran d'inscription (préparé pour l'avenir)
@@ -89,10 +92,10 @@ constants/                    # Constantes de l'app
 
 | Route | Fichier | Type | Description | Navigation |
 |-------|---------|------|-------------|------------|
-| `/` | `app/index.tsx` | Redirect | Point d'entrée avec persistance | → `/(main)/home` |
-| `/(main)/home` | `app/(main)/home.tsx` | Tab | Page d'accueil principale | Onglet "Accueil" |
-| `/(main)/tp1-profile-card` | `app/(main)/tp1-profile-card.tsx` | Tab | Carte de profil interactive (TP1) | Onglet "Profile Card" |
-| `/(main)/detail/[id]` | `app/(main)/detail/[id].tsx` | Stack | Page de détail avec paramètre dynamique | Masquée des onglets |
+| `/` | `app/index.tsx` | Redirect | Point d'entrée avec persistance | → `/(main)/(tabs)/home` |
+| `/(main)/(tabs)/home` | `app/(main)/(tabs)/home.tsx` | Tab | Page d'accueil principale | Onglet "Accueil" |
+| `/(main)/(tabs)/tp1-profile-card` | `app/(main)/(tabs)/tp1-profile-card.tsx` | Tab | Carte de profil interactive (TP1) | Onglet "Profile Card" |
+| `/(main)/detail/[id]` | `app/(main)/detail/[id].tsx` | Stack | Page de détail avec bouton retour natif | Header iOS avec geste "liquid" |
 | `/(auth)/login` | `app/(auth)/login.tsx` | Stack | Écran de connexion | Modal d'authentification |
 | `/(auth)/register` | `app/(auth)/register.tsx` | Stack | Écran d'inscription | Modal d'authentification |
 
@@ -112,6 +115,7 @@ constants/                    # Constantes de l'app
 - ✅ **Navigation par onglets** gérée directement depuis la racine
 - ✅ **Écrans masqués** (détail, auth) via `href: null`
 - ✅ **Validation des paramètres** avec écran d'erreur 404
+- ✅ **Bouton retour natif iOS** avec geste "liquid" interactif
 
 ### Passage de paramètres
 - ✅ Route dynamique `/detail/[id]` avec validation robuste
@@ -282,6 +286,60 @@ rnadvancedlabs://detail/trop-long-id-invalide → Écran 404 (ID trop long)
 - ✅ Validation des paramètres avant navigation
 - ✅ Logs détaillés pour le débogage
 
+## 🔙 Bouton Retour Natif iOS
+
+### 🎯 **Configuration**
+
+L'application utilise le **Native Stack Navigator** d'Expo Router pour bénéficier du bouton retour natif iOS avec toutes ses fonctionnalités.
+
+**Structure :**
+```
+app/(main)/_layout.tsx    # Stack Navigator avec options natives
+├── (tabs)/               # Groupe Tabs (Accueil + Profil)
+└── detail/[id].tsx       # Écran avec bouton retour natif
+```
+
+### ✨ **Fonctionnalités natives iOS**
+
+- ✅ **Bouton chevron natif** : Icône iOS officielle sans texte (`headerBackButtonDisplayMode: "minimal"`)
+- ✅ **Geste "liquid"** : Glissement interactif depuis le bord gauche de l'écran
+- ✅ **Animation fluide** : Transition native iOS entre les écrans
+- ✅ **Haptic feedback** : Retour haptique lors de l'interaction
+
+### 🎮 **Utilisation**
+
+1. **Navigation vers Détail** : Depuis Accueil ou Profil → "Voir Détail (ID: 42)"
+2. **Retour par bouton** : Appuyer sur le chevron en haut à gauche
+3. **Retour par geste** : Glisser depuis le bord gauche vers la droite
+4. **Retour programmatique** : `router.back()` en cas d'erreur
+
+### ⚙️ **Configuration technique**
+
+```typescript
+// app/(main)/_layout.tsx
+<Stack
+  screenOptions={{
+    headerShown: true,
+    gestureEnabled: true,                    // Active le geste de retour
+    headerBackButtonDisplayMode: "minimal", // Masque le texte, garde l'icône
+  }}
+>
+  <Stack.Screen
+    name="detail/[id]"
+    options={{
+      title: "Détail",
+      presentation: "card", // Animation de présentation en carte
+    }}
+  />
+</Stack>
+```
+
+### 📱 **Comportement UX**
+
+- **TabBar masquée** : Sur l'écran Détail, seul le header Stack est visible
+- **TabBar visible** : Sur Accueil et Profil, les onglets restent accessibles
+- **Navigation cohérente** : Le retour ramène toujours vers l'onglet d'origine
+
 ---
 
 ## 🛠️ Technologies utilisées
@@ -322,6 +380,7 @@ rnadvancedlabs://detail/trop-long-id-invalide → Écran 404 (ID trop long)
 - [x] Deep linking complet (cold/warm/hot)
 - [x] Gestion d'erreurs et écrans 404
 - [x] Architecture propre avec un seul layout racine
+- [x] Bouton retour natif iOS avec geste "liquid" interactif
 
 ---
 

--- a/app/(main)/(tabs)/_layout.tsx
+++ b/app/(main)/(tabs)/_layout.tsx
@@ -1,0 +1,34 @@
+import { Tabs } from "expo-router";
+import { IconSymbol } from "../../../components/ui/icon-symbol";
+
+export default function TabsLayout() {
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: true,
+        tabBarActiveTintColor: "#3b82f6",
+      }}
+    >
+      <Tabs.Screen
+        name="home"
+        options={{
+          title: "Accueil",
+          headerTitle: "RN Advanced Labs",
+          tabBarIcon: ({ color }) => (
+            <IconSymbol name="house.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="tp1-profile-card"
+        options={{
+          title: "Profil",
+          headerTitle: "Profile Card - TP1",
+          tabBarIcon: ({ color }) => (
+            <IconSymbol name="person.fill" color={color} />
+          ),
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/app/(main)/(tabs)/home.tsx
+++ b/app/(main)/(tabs)/home.tsx
@@ -12,21 +12,27 @@ export default function HomeScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Bienvenue 👋</Text>
-      <Text style={styles.subtitle}>
-        Laboratoires avancés React Native
-      </Text>
+      <Text style={styles.subtitle}>Laboratoires avancés React Native</Text>
+
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Navigation TP2</Text>
         <Text style={styles.cardDescription}>
           Structure de navigation avec Stack et Tabs configurée avec succès !
         </Text>
-        
-        <Link href="/detail/42" asChild>
+
+        <Link href="/(main)/detail/42" asChild>
           <TouchableOpacity style={styles.detailButton}>
             <Text style={styles.detailButtonText}>Voir Détail (ID: 42)</Text>
           </TouchableOpacity>
         </Link>
 
+        <View style={{ height: 12 }} />
+
+        <Link href="/(main)/(tabs)/tp1-profile-card" asChild>
+          <TouchableOpacity style={[styles.detailButton, { backgroundColor: "#10b981" }]}>
+            <Text style={styles.detailButtonText}>Aller au Profil</Text>
+          </TouchableOpacity>
+        </Link>
       </View>
     </View>
   );
@@ -86,19 +92,6 @@ const styles = StyleSheet.create({
   detailButtonText: {
     color: "#fff",
     fontSize: 16,
-    fontWeight: "600",
-  },
-  deepLinkButton: {
-    backgroundColor: "#10b981",
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-    borderRadius: 8,
-    alignItems: "center",
-    marginTop: 12,
-  },
-  deepLinkButtonText: {
-    color: "#fff",
-    fontSize: 14,
     fontWeight: "600",
   },
 });

--- a/app/(main)/(tabs)/tp1-profile-card.tsx
+++ b/app/(main)/(tabs)/tp1-profile-card.tsx
@@ -104,7 +104,7 @@ export default function ProfileCard() {
       <Text style={styles.timer}>{timer} seconds</Text>
 
 
-      <Link href="/detail/42" asChild>
+      <Link href="/(main)/detail/42" asChild>
           <TouchableOpacity style={styles.detailButton}>
             <Text style={styles.detailButtonText}>Voir Détail (ID: 42)</Text>
           </TouchableOpacity>

--- a/app/(main)/_layout.tsx
+++ b/app/(main)/_layout.tsx
@@ -1,0 +1,27 @@
+import { Stack } from "expo-router";
+
+export default function MainLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: true,
+        gestureEnabled: true,
+        headerBackButtonDisplayMode: "minimal",
+      }}
+    >
+      <Stack.Screen
+        name="(tabs)"
+        options={{
+          headerShown: false, // Les tabs gèrent leur propre header
+        }}
+      />
+      <Stack.Screen
+        name="detail/[id]"
+        options={{
+          title: "Détail",
+          presentation: "card",
+        }}
+      />
+    </Stack>
+  );
+}

--- a/app/(main)/detail/[id].tsx
+++ b/app/(main)/detail/[id].tsx
@@ -1,4 +1,3 @@
-import { useNavigation } from "@react-navigation/native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
@@ -10,66 +9,38 @@ interface ValidationResult {
 }
 
 function validateId(id: string | string[]): ValidationResult {
-  // Gérer le cas où id est un array (ne devrait pas arriver avec [id].tsx)
   const idStr = Array.isArray(id) ? id[0] : id;
-  
+
   if (!idStr) {
     return { isValid: false, error: "ID manquant" };
   }
-
-  // Vérifier que c'est un nombre ou une chaîne valide
-  if (typeof idStr !== 'string') {
+  if (typeof idStr !== "string") {
     return { isValid: false, error: "Format d'ID invalide" };
   }
 
-  // Nettoyer l'ID (supprimer espaces, caractères spéciaux dangereux)
   const sanitizedId = idStr.trim();
-  
   if (sanitizedId.length === 0) {
     return { isValid: false, error: "ID vide" };
   }
-
-  // Vérifier la longueur (éviter les IDs trop longs)
   if (sanitizedId.length > 50) {
     return { isValid: false, error: "ID trop long" };
   }
-
-  // Optionnel : vérifier si c'est un nombre si requis
-  // if (!/^\d+$/.test(sanitizedId)) {
-  //   return { isValid: false, error: "L'ID doit être numérique" };
-  // }
 
   return { isValid: true, sanitizedId };
 }
 
 export default function DetailScreen() {
   const { id } = useLocalSearchParams();
-  const navigation = useNavigation();
   const router = useRouter();
-  const [validationResult, setValidationResult] = useState<ValidationResult>({ isValid: true });
+  const [validationResult, setValidationResult] = useState<ValidationResult>({
+    isValid: true,
+  });
 
   useEffect(() => {
-    console.log(`🔍 DetailScreen - Écran de détail monté avec ID: ${id}`);
-    
-    // Valider l'ID
-    const validation = validateId(id);
-    setValidationResult(validation);
+    console.log(`🔍 DetailScreen monté avec ID: ${id}`);
+    setValidationResult(validateId(id));
+  }, [id]);
 
-    if (validation.isValid) {
-      navigation.setOptions({
-        title: `Détail (ID: ${validation.sanitizedId})`,
-      });
-    } else {
-      navigation.setOptions({
-        title: "Erreur - ID invalide",
-      });
-      console.warn(`⚠️ ID invalide détecté: ${id} - ${validation.error}`);
-    }
-  }, [navigation, id]);
-
-  console.log(`🔄 DetailScreen - Rendu de l'écran de détail, ID: ${id}`);
-
-  // Afficher l'écran d'erreur si l'ID n'est pas valide
   if (!validationResult.isValid) {
     return (
       <View style={styles.container}>
@@ -78,14 +49,12 @@ export default function DetailScreen() {
           <Text style={styles.errorTitle}>ID Invalide</Text>
           <Text style={styles.errorMessage}>{validationResult.error}</Text>
           <Text style={styles.errorDetails}>
-            ID reçu : "{Array.isArray(id) ? id.join(', ') : id}"
+            ID reçu : "{Array.isArray(id) ? id.join(", ") : id}"
           </Text>
-          
-          <TouchableOpacity 
+
+          <TouchableOpacity
             style={styles.backButton}
-            onPress={() => {
-              router.replace('/(main)/home');
-            }}
+            onPress={() => router.replace("/(main)/(tabs)/home")}
           >
             <Text style={styles.backButtonText}>← Retour à l'accueil</Text>
           </TouchableOpacity>
@@ -103,8 +72,8 @@ export default function DetailScreen() {
         <Text style={styles.validBadge}>✅ ID validé</Text>
       </View>
       <Text style={styles.description}>
-        Cet écran utilise un paramètre dynamique récupéré via l'URL.
-        L'ID a été validé et nettoyé pour la sécurité.
+        Cet écran utilise un paramètre dynamique récupéré via l'URL. L'ID a été
+        validé et nettoyé pour la sécurité.
       </Text>
     </View>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,105 +1,31 @@
-import { Ionicons } from "@expo/vector-icons";
-import { Tabs } from "expo-router";
+import { Stack } from "expo-router";
 import { useEffect } from "react";
 import { DeepLinkHandler } from "../components/deep-link-handler";
 import { useRoutePersistence } from "../hooks/use-route-persistence";
 
 /**
- * Layout racine UNIQUE de l'application
- * Gère directement la navigation par onglets
- * Groupes (main) et (auth) distincts SANS leurs propres layouts
- * Seuls Accueil et Profile Card visibles dans les onglets
+ * Stack global :
+ * - Header visible partout
+ * - Retour automatique sauf sur Home
+ * - Écrans d'auth sans header
  */
 export default function RootLayout() {
   useRoutePersistence();
 
   useEffect(() => {
-    console.log("🏗️ RootLayout - Layout racine unique avec groupes distincts");
+    // console.log("🏗️ RootLayout - UN SEUL LAYOUT pour toute l'app");
   }, []);
 
   return (
     <>
       <DeepLinkHandler />
-      
-      <Tabs
-        screenOptions={{
-          tabBarActiveTintColor: "#3b82f6",
-          tabBarInactiveTintColor: "#6b7280", 
-          headerShown: true,
-          tabBarStyle: {
-            paddingBottom: 8,
-            height: 88,
-          },
-          tabBarLabelStyle: {
-            fontSize: 12,
-            fontWeight: "500",
-          },
-        }}
-      >
-        {/* GROUPE (main) - 2 ONGLETS VISIBLES */}
-        
-        <Tabs.Screen
-          name="(main)/home"
-          options={{
-            title: "Accueil",
-            tabBarIcon: ({ color, focused }) => (
-              <Ionicons 
-                name={focused ? "home" : "home-outline"} 
-                size={24} 
-                color={color} 
-              />
-            ),
-            headerTitle: "RN Advanced Labs",
-          }}
-        />
-        
-        <Tabs.Screen
-          name="(main)/tp1-profile-card"
-          options={{
-            title: "Profile Card", 
-            tabBarIcon: ({ color, focused }) => (
-              <Ionicons 
-                name={focused ? "person" : "person-outline"} 
-                size={24} 
-                color={color} 
-              />
-            ),
-            headerTitle: "Profile Card - TP1",
-          }}
-        />
-        
-        {/* TOUS LES AUTRES ÉCRANS MASQUÉS */}
-        <Tabs.Screen
-          name="index"
-          options={{
-            href: null, // Masquer index des onglets
-          }}
-        />
-        
-        <Tabs.Screen
-          name="(main)/detail/[id]"
-          options={{
-            href: null, // Masquer détail des onglets
-            headerTitle: "Détail",
-          }}
-        />
-        
-        <Tabs.Screen
-          name="(auth)/login"
-          options={{
-            href: null, // Masquer login des onglets
-            headerShown: false,
-          }}
-        />
-        
-        <Tabs.Screen
-          name="(auth)/register"
-          options={{
-            href: null, // Masquer register des onglets
-            headerShown: false,
-          }}
-        />
-      </Tabs>
+
+      {/* Stack racine qui accueille les groupes (main) et (auth) */}
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen name="(main)" options={{ headerShown: false }} />
+        <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+      </Stack>
     </>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,29 +2,35 @@ import { Redirect } from "expo-router";
 import { useEffect, useState } from "react";
 import { getLastRoute } from "../hooks/use-route-persistence";
 
+/**
+ * Point d’entrée : choisit la route de départ.
+ * - Si une dernière route existe, on y va
+ * - Sinon on va vers /home
+ * On renvoie null pendant le chargement pour éviter tout flash.
+ */
 export default function Index() {
-  const [lastRoute, setLastRoute] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [targetRoute, setTargetRoute] = useState<string | null>(null);
 
   useEffect(() => {
-    console.log("🚀 Index.tsx - Composant monté");
-    
-    const loadLastRoute = async () => {
-      const savedRoute = await getLastRoute();
-      setLastRoute(savedRoute);
-      setIsLoading(false);
-    };
+    let mounted = true;
 
-    loadLastRoute();
+    (async () => {
+      const saved = await getLastRoute();
+      if (!mounted) return;
+
+      // Fallback propre vers /home
+      setTargetRoute(saved || "/(main)/home");
+    })();
+
+    return () => {
+      mounted = false;
+    };
   }, []);
 
-  if (isLoading) {
-    console.log("⏳ Index.tsx - Chargement en cours...");
+  if (!targetRoute) {
+    // Évite d'afficher quoi que ce soit avant d'avoir la route cible
     return null;
   }
 
-  const targetRoute = lastRoute || "/(main)/home";
-  console.log("🔄 Index.tsx - Redirection vers:", targetRoute);
-  
   return <Redirect href={targetRoute as any} />;
 }

--- a/components/deep-link-handler.tsx
+++ b/components/deep-link-handler.tsx
@@ -1,113 +1,128 @@
-import { useRouter } from 'expo-router';
-import { useEffect } from 'react';
-import { Linking } from 'react-native';
+import { usePathname, useRouter } from "expo-router";
+import { useEffect, useRef } from "react";
+import { Linking } from "react-native";
 
 /**
- * Composant pour gérer les deep links entrants
+ * Gère les deep links entrants (expo go et schéma natif).
+ * - Ignore l’URL racine Expo Go (exp://host:port) pour éviter une 2e redirection vers /home
+ * - Ne navigue que si la cible est différente de la route courante
  */
 export function DeepLinkHandler() {
   const router = useRouter();
+  const pathname = usePathname();
+  const isHandlingRef = useRef(false);
 
   useEffect(() => {
-    let isHandlingLink = false;
+    const setHandling = (v: boolean) => (isHandlingRef.current = v);
 
-    // Gérer les liens lors du lancement de l'app
+    const navigateIfNeeded = (target: string) => {
+      // Normalise quelques cas
+      const normalized =
+        target === "/" || target === "" || target === "/home"
+          ? "/(main)/home"
+          : target.startsWith("/(main)") || target.startsWith("/(auth)")
+          ? target
+          : `/(main)${target.startsWith("/") ? target : `/${target}`}`;
+
+      if (pathname === normalized) {
+        // console.log("ℹ️ Déjà sur la bonne route → pas de navigation:", normalized);
+        return;
+      }
+      // console.log("🔄 Navigation via deep link →", normalized);
+      router.replace(normalized as any);
+    };
+
+    const parseToPath = (url: string): string | null => {
+      try {
+        // 1) Expo Go: exp://<host>:<port>[/path]
+        if (url.startsWith("exp://")) {
+          const match = url.match(/exp:\/\/[^/]+(.*)$/);
+          const path = (match?.[1] || "").trim();
+
+          // Si pas de chemin → c’est juste l’URL racine d’Expo Go, on ignore
+          if (!path || path === "/") {
+            // console.log("ℹ️ URL Expo Go racine détectée → on ignore");
+            return null;
+          }
+          // S’assure de commencer par /
+          return path.startsWith("/") ? path : `/${path}`;
+        }
+
+        // 2) Schéma natif: rnadvancedlabs://path
+        if (url.startsWith("rnadvancedlabs://")) {
+          const path = url.replace(/^rnadvancedlabs:\/\//, "").trim();
+          return path ? (path.startsWith("/") ? path : `/${path}`) : "/";
+        }
+
+        // Autres schémas: on ignore
+        // console.log("ℹ️ Schéma non géré →", url);
+        return null;
+      } catch (e) {
+        console.log("❌ Erreur parse URL:", e);
+        return null;
+      }
+    };
+
+    const handleDeepLink = (url: string) => {
+      if (isHandlingRef.current) return;
+      setHandling(true);
+
+      try {
+        // console.log("🔗 URL à traiter:", url);
+        const path = parseToPath(url);
+        if (!path) {
+          // Rien à faire (ex: exp://host:port sans chemin)
+          return;
+        }
+
+        // Petit délai pour laisser le temps au layout/stack d’être prêt
+        setTimeout(() => {
+          try {
+            if (path === "/tp1-profile-card") {
+              navigateIfNeeded("/(main)/tp1-profile-card");
+            } else if (path.startsWith("/detail/")) {
+              navigateIfNeeded(`/(main)${path}`);
+            } else if (path === "/home" || path === "/" || path === "") {
+              navigateIfNeeded("/(main)/home");
+            } else {
+              // console.log("⚠️ Chemin non reconnu, fallback → /home :", path);
+              navigateIfNeeded("/(main)/home");
+            }
+          } finally {
+            setHandling(false);
+          }
+        }, 300);
+      } catch (e) {
+        console.log("❌ Erreur handleDeepLink:", e);
+        setHandling(false);
+      }
+    };
+
     const handleInitialURL = async () => {
-      if (isHandlingLink) return;
-      
       try {
         const initialURL = await Linking.getInitialURL();
         if (initialURL) {
-          console.log('🔗 Deep link initial détecté:', initialURL);
+          // console.log("🔗 Deep link initial détecté:", initialURL);
           handleDeepLink(initialURL);
         }
       } catch (error) {
-        console.log('❌ Erreur récupération URL initiale:', error);
+        console.log("❌ Erreur récupération URL initiale:", error);
       }
     };
 
-    // Gérer les liens lorsque l'app est déjà ouverte
-    const handleURL = (event: { url: string }) => {
-      if (isHandlingLink) return;
-      
-      console.log('🔗 Deep link reçu:', event.url);
+    const subscription = Linking.addEventListener("url", (event) => {
+      // console.log("🔗 Deep link reçu (event):", event.url);
       handleDeepLink(event.url);
-    };
+    });
 
-    // Parser et router vers la bonne page
-    const handleDeepLink = (url: string) => {
-      if (isHandlingLink) return;
-      isHandlingLink = true;
-      
-      try {
-        console.log('🔗 URL à traiter:', url);
-        
-        let path = '';
-        
-        // Gérer les différents formats d'URL
-        if (url.includes('exp://')) {
-          // Format Expo Go: exp://10.25.128.212:8081/tp1-profile-card
-          const match = url.match(/exp:\/\/[^\/]+(.*)$/);
-          path = match ? match[1] : '';
-        } else if (url.startsWith('rnadvancedlabs://')) {
-          // Format schéma personnalisé: rnadvancedlabs://tp1-profile-card
-          path = url.replace(/^rnadvancedlabs:\/\//, '');
-        }
-        
-        // S'assurer que le path commence par /
-        if (path && !path.startsWith('/')) {
-          path = '/' + path;
-        }
-        
-        console.log('🎯 Chemin extrait:', path);
-        
-        // Délai pour laisser le temps à l'app de se charger
-        setTimeout(() => {
-          try {
-            // Router vers le bon écran
-            if (path === '/tp1-profile-card') {
-              console.log('🔄 Navigation vers profile card');
-              router.replace('/(main)/tp1-profile-card');
-            } else if (path.startsWith('/detail/')) {
-              const fullPath = `/(main)${path}`;
-              console.log('🔄 Navigation vers détail:', fullPath);
-              router.replace(fullPath as any);
-            } else if (path === '/home' || path === '/' || path === '') {
-              console.log('🔄 Navigation vers home');
-              router.replace('/(main)/home');
-            } else {
-              console.log('⚠️ Chemin non reconnu:', path, '- redirection vers home');
-              router.replace('/(main)/home');
-            }
-          } catch (navError) {
-            console.log('❌ Erreur navigation:', navError);
-            router.replace('/(main)/home');
-          } finally {
-            isHandlingLink = false;
-          }
-        }, 500);
-        
-      } catch (error) {
-        console.log('❌ Erreur parsing deep link:', error);
-        router.replace('/(main)/home');
-        isHandlingLink = false;
-      }
-    };
+    // Laisse le temps au Router de se monter avant d’analyser l’URL initiale
+    const timer = setTimeout(handleInitialURL, 600);
 
-    // Écouter les événements
-    const subscription = Linking.addEventListener('url', handleURL);
-    
-    // Délai pour s'assurer que l'app est prête
-    const timer = setTimeout(() => {
-      handleInitialURL();
-    }, 1000);
-
-    // Cleanup
     return () => {
-      subscription?.remove();
+      subscription.remove();
       clearTimeout(timer);
     };
-  }, [router]);
+  }, [router, pathname]);
 
-  return null; // Composant invisible
+  return null;
 }

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -1,7 +1,7 @@
 // Fallback for using MaterialIcons on Android and web.
 
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
+import { SymbolViewProps, SymbolWeight } from 'expo-symbols';
 import { ComponentProps } from 'react';
 import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
 
@@ -18,6 +18,8 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'person.fill': 'person',
+  'chevron.left': 'chevron-left',
 } as IconMapping;
 
 /**

--- a/hooks/use-route-persistence.ts
+++ b/hooks/use-route-persistence.ts
@@ -16,7 +16,7 @@ export function useRoutePersistence() {
         // Ne pas sauvegarder la route racine "/"
         if (pathname && pathname !== '/') {
           await AsyncStorage.setItem(LAST_ROUTE_KEY, pathname);
-          console.log(`💾 Route sauvegardée automatiquement: ${pathname}`);
+          // console.log(`💾 Route sauvegardée automatiquement: ${pathname}`);
         }
       } catch (error) {
         console.log('❌ Erreur sauvegarde route:', error);


### PR DESCRIPTION
Architecture:
- Refactorisation Stack/Tabs avec app/(main)/_layout.tsx
- Création groupe (tabs) pour onglets Accueil + Profil
- Déplacement detail/[id] au niveau Stack pour bouton retour natif

UI/UX:
- Remplacement emojis par IconSymbol (SF Symbols iOS + Material Android)
- Bouton retour natif iOS avec headerBackButtonDisplayMode: minimal
- Geste liquid interactif depuis bord gauche écran
- TabBar visible sur onglets, masquée sur détail

Techniques:
- gestureEnabled: true pour interaction native
- presentation: card pour animation fluide
- Mise à jour routes: /(main)/(tabs)/home, /(main)/detail/[id]
- Conservation persistance navigation et deep linking

Documentation:
- Section complète bouton retour natif dans README
- Architecture mise à jour avec nouvelle structure
- Guide utilisation geste liquid et configuration technique