### PR TITLE
feat: implement robots CRUD with Zustand, persistence, and create/edi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# RN-Advanced-Labs 📱
+# RN-Advanced-Labs
 
 Laboratoire avancé de développement React Native avec Expo Router.
 
-## 🚀 Démarrage rapide
+## Démarrage rapide
 
 1. Installation des dépendances
 
@@ -21,159 +21,6 @@ Vous pouvez ouvrir l'app dans :
 - [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
 - [Expo Go](https://expo.dev/go)
 
----
-
-# Travaux Pratiques
-
-## TP1 - Profile Card Screen
-
-### **Localisation**
-[`app/(main)/(tabs)/tp1-profile-card.tsx`](./app/(main)/(tabs)/tp1-profile-card.tsx)
-
-### **Description**
-Écran de carte de profil interactif comprenant :
-- **Affichage profil** : Photo, nom, rôle utilisateur
-- **Follow/Unfollow** : Système interactif avec styles dynamiques
-- **Timer manuel** : Contrôles start/reset avec état local
-- **Auto-increment** : Compteur de followers (toutes les 5 secondes)
-- **Design moderne** : Responsive avec effets d'ombre et animations
-
-### **Objectifs pédagogiques**
-- [x] État local avec `useState` et `useRef`
-- [x] Gestion des timers et intervalles
-- [x] Styles dynamiques et animations
-- [x] Design responsive et moderne
-
-### **Status** 
-**Terminé** (Tag: `tp1-done`)
-
----
-
-## TP2 - Navigation, Persistance & Deep Linking
-
-### **Localisation**
-Architecture complète `app/` avec Expo Router
-
-### **Description**
-- **Navigation multi-écrans** avec Expo Router (file-based routing)
-- **Architecture Stack + Tabs** avec layouts imbriqués
-- **Paramètres dynamiques** avec validation robuste
-- **Persistance navigation** (retour à la dernière page)
-- **Deep linking complet** (cold/warm/hot start)
-- **Bouton retour natif** iOS avec geste "liquid"
-
-### **Objectifs pédagogiques**
-- [x] Architecture file-based routing avec Expo Router
-- [x] Navigation par onglets et stack imbriqués
-- [x] Passage de paramètres avec validation
-- [x] Persistance de l'état de navigation
-- [x] Deep linking complet (cold/warm/hot)
-- [x] Gestion d'erreurs et écrans 404
-- [x] Architecture propre avec un seul layout racine
-- [x] Bouton retour natif iOS avec geste "liquid" interactif
-
-### **Status**
-**Terminé** (Tag: `tp2-done`)
-
-### **Navigation et Deep Linking**
-
-#### **Table des Routes**
-
-| Route | Description | Type | Navigation |
-|-------|-------------|------|------------|
-| `/` | Point d'entrée avec persistance | Redirect | → `/(main)/(tabs)/home` |
-| `/(main)/(tabs)/home` | Page d'accueil avec liens vers TP3 | Tab | Onglet "Accueil" |
-| `/(main)/(tabs)/tp1-profile-card` | Carte de profil interactive (TP1) | Tab | Onglet "Profil" |
-| `/(main)/(tabs)/tp3-forms` | Vue d'ensemble des formulaires | Tab | Onglet "Formulaires" |
-| `/(main)/(tabs)/tp3-forms/formik` | Formulaire Formik + Yup | Stack | Accès direct en 2 taps |
-| `/(main)/(tabs)/tp3-forms/rhf` | Formulaire RHF + Zod | Stack | Accès direct en 2 taps |
-| `/(main)/detail/[id]` | Page de détail avec bouton retour natif | Stack | Header iOS avec geste "liquid" |
-
-#### **Deep Links disponibles**
-
-```bash
-# Navigation principale
-rnadvancedlabs://                    → Page d'accueil
-rnadvancedlabs://tp1-profile-card    → Profile Card  
-
-# Navigation avec paramètres
-rnadvancedlabs://detail/42           → Écran de détail (ID: 42)
-rnadvancedlabs://detail/123          → Écran de détail (ID: 123)
-
-# Navigation TP3 - Formulaires
-rnadvancedlabs://tp3-forms           → Vue d'ensemble des formulaires
-rnadvancedlabs://tp3-forms/formik    → Formulaire Formik + Yup
-rnadvancedlabs://tp3-forms/rhf       → Formulaire RHF + Zod
-
-# Gestion d'erreurs
-rnadvancedlabs://detail/             → Écran 404 (ID manquant)
-```
-
-#### **Bouton Retour Natif iOS**
-
-- **Bouton chevron natif** : Icône iOS officielle sans texte
-- **Geste "liquid"** : Glissement interactif depuis le bord gauche
-- **Animation fluide** : Transition native iOS entre les écrans
-- **Haptic feedback** : Retour haptique lors de l'interaction
-
----
-
-## TP3 - Formulaires avancés avec validation temps réel
-
-### **Localisation**
-`app/(main)/(tabs)/tp3-forms/` avec arborescence structurée
-
-### **Description**
-- **Deux implémentations** de formulaires d'inscription identiques
-- **Formik + Yup** : Gestion classique avec `useField` et validation Yup
-- **React Hook Form + Zod** : Performance optimisée avec `Controller` et validation Zod
-- **Validation temps réel** avec messages d'erreur dynamiques
-- **Design moderne** avec placeholders personnalisés et animations
-- **Navigation croisée** pour comparer les deux approches
-- **Submit bloqué** si formulaire invalide ou non modifié
-- **Instrumentation** et mesure des performances avec logs
-
-### **Objectifs pédagogiques**
-- [x] Deux implémentations identiques (Formik + Yup vs RHF + Zod)
-- [x] Arborescence respectée avec validation/ et components/ séparés
-- [x] Navigation directe en 2 taps maximum depuis l'accueil
-- [x] Liens croisés Formik ⇄ RHF pour comparaison rapide
-- [x] Validation temps réel avec messages d'erreur
-- [x] Submit bloqué si formulaire invalide ou non modifié
-- [x] Design moderne avec placeholders personnalisés
-- [x] Retour fonctionnel avec header natif
-- [x] Instrumentation et mesure des performances avec logs
-
-### **Status**
-**Terminé** (Tag: `tp3-done`)
-
-### **Navigation TP3**
-
-#### **Accès direct en 2 taps maximum**
-
-**Depuis l'écran d'accueil :**
-1. **Tap 1** : Bouton "TP3 – Formik" → `/(main)/(tabs)/tp3-forms/formik`
-2. **Tap 1** : Bouton "TP3 – RHF" → `/(main)/(tabs)/tp3-forms/rhf`
-
-**Depuis l'onglet Formulaires :**
-1. **Tap 1** : Onglet "Formulaires" → Vue d'ensemble
-2. **Tap 2** : Bouton vers Formik ou RHF
-
-#### **Liens croisés**
-
-Chaque écran de formulaire contient un bouton de navigation croisée :
-- **Formik** → Bouton "Basculer vers RHF + Zod"
-- **RHF** → Bouton "Basculer vers Formik + Yup"
-
-#### **Retour fonctionnel**
-
-- **Header natif** avec bouton retour iOS
-- **Geste liquid** depuis le bord gauche
-- **Navigation programmatique** avec `router.back()`
-- **Pile de navigation** préservée
-
----
-
 ## Architecture du Projet
 
 ```
@@ -183,8 +30,8 @@ app/
   (main)/                     # Groupe principal avec Stack Navigator
     _layout.tsx               # Stack avec bouton retour natif iOS
     (tabs)/                   # Groupe onglets
-      _layout.tsx             # Tabs Navigator (Accueil + Profil + Formulaires)
-      home.tsx                # Page d'accueil avec liens vers TP3
+      _layout.tsx             # Tabs Navigator (Accueil + Profil + Formulaires + Robots)
+      home.tsx                # Page d'accueil avec liens vers TP3/TP4
       tp1-profile-card.tsx    # Écran du TP1 (intégré à la navigation)
       tp3-forms/              # TP3 - Formulaires avancés
         _layout.tsx           # Stack Navigator pour les formulaires
@@ -203,6 +50,11 @@ app/
           components/
             FormField.tsx     # Composant champ avec Controller
             CheckboxField.tsx # Composant checkbox avec Controller
+      tp4-robots/             # TP4 - Liste + Création + Édition (Zustand)
+        _layout.tsx           # Stack Navigator pour TP4
+        index.tsx             # Liste des robots
+        create.tsx            # Création d'un robot
+        edit/[id].tsx         # Édition d'un robot
     detail/
       [id].tsx                # Écran dynamique avec bouton retour natif
   (auth)/                     # Groupe authentification (PAS de _layout.tsx)
@@ -217,6 +69,9 @@ components/                   # Composants partagés
   themed-text.tsx
   themed-view.tsx
   ui/                         # Composants UI spécialisés
+  robots/                     # Composants TP4
+    RobotForm.tsx             # Formulaire Create/Edit réutilisable
+    RobotListItem.tsx         # Item de liste avec actions
 hooks/                        # Hooks personnalisés
   use-route-persistence.ts    # Gestion persistance navigation
   use-color-scheme.ts         # Gestion des thèmes
@@ -225,15 +80,11 @@ lib/                          # Services et utilitaires
   deep-link-utils.ts          # Utilitaires pour deep linking
 constants/                    # Constantes de l'app
   theme.ts                    # Configuration des thèmes
+store/
+  robotsStore.ts              # Store Zustand (TP4) avec persistance
+validation/
+  robotSchema.ts              # Schéma Zod (TP4)
 ```
-
-### **Validation des Paramètres**
-
-| Paramètre | Validation | Comportement |
-|-----------|------------|--------------|
-| `[id]` | Non vide, longueur < 50 caractères | Écran d'erreur 404 si invalide |
-| `[id]` | Nettoyage automatique (trim) | Sécurisation des entrées utilisateur |
-| `[id]` | Gestion des tableaux | Protection contre les paramètres malformés |
 
 ## Fonctionnalités
 
@@ -251,6 +102,14 @@ constants/                    # Constantes de l'app
 - Écran d'erreur 404 pour les paramètres invalides
 - Titre de page dynamique selon l'ID validé
 - Navigation de retour native et programmatique
+
+### Validation des Paramètres
+
+| Paramètre | Validation | Comportement |
+|-----------|------------|--------------|
+| `[id]` | Non vide, longueur < 50 caractères | Écran d'erreur 404 si invalide |
+| `[id]` | Nettoyage automatique (trim) | Sécurisation des entrées utilisateur |
+| `[id]` | Gestion des tableaux | Protection contre les paramètres malformés |
 
 ## Persistance de l'état de navigation
 
@@ -284,36 +143,13 @@ constants/                    # Constantes de l'app
 
 ### Choix UX
 
-🎯 **Persistance complète** : L'utilisateur retrouve exactement où il était, même dans un écran de détail profond.
+**Persistance complète** : L'utilisateur retrouve exactement où il était, même dans un écran de détail profond.
 
-⚠️ **Alternative possible** : Utiliser `unstable_settings.initialRouteName` pour forcer un retour à l'accueil, mais cela casse l'expérience utilisateur.
+**Alternative possible** : Utiliser `unstable_settings.initialRouteName` pour forcer un retour à l'accueil, mais cela casse l'expérience utilisateur.
 
-## 🚀 Utilisation
+## Deep Linking
 
-```bash
-# Installation des dépendances
-npm install
-
-# Démarrage
-npm start
-```
-
-## 📦 Dépendances clés
-
-- `expo-router` : Navigation file-based
-- `@react-native-async-storage/async-storage` : Persistance locale
-- `@expo/vector-icons` : Icônes pour les onglets
-
-## 🧪 Test de la persistance
-
-1. Naviguez vers "Profile Card" puis "Voir Détail (ID: 42)"
-2. Fermez complètement l'application
-3. Relancez → Vous devriez être sur l'écran de détail
-4. Le bouton retour fonctionne pour revenir à l'accueil
-
-## 🔗 Deep Linking
-
-### 📋 Configuration
+### Configuration
 
 Dans `app.json` :
 ```json
@@ -332,21 +168,21 @@ Dans `app.json` :
 - **Liens web** : `https://app.votre-domaine.com/...` (préparé)
 - **Bundle identifiers** : iOS et Android configurés
 
-### 🚀 Situation actuelle et solutions
+### Situation actuelle et solutions
 
-#### 📱 **Expo Go - Limitations**
+#### Expo Go - Limitations
 - ✅ **Fonctionne** : `exp://10.25.128.212:8081` (racine uniquement)
 - ❌ **Ne fonctionne pas** : `exp://10.25.128.212:8081/tp1-profile-card`
 
 **Pourquoi ?** Expo Go attend un manifest JSON uniquement à la racine. Impossible de lancer directement une route spécifique.
 
-#### 🔧 **Schéma personnalisé (rnadvancedlabs://)**
+#### Schéma personnalisé (rnadvancedlabs://)
 - ✅ **Bien déclaré** dans `app.json`
 - ❌ **Safari ne peut pas ouvrir** `rnadvancedlabs://tp1-profile-card` dans Expo Go
 
 **Pourquoi ?** Expo Go ne connaît pas votre schéma personnalisé. Safari affiche "adresse invalide".
 
-#### 🏗️ **Dev Build - Solution complète**
+#### Dev Build - Solution complète
 
 Pour tester les deep links avec schéma personnalisé, il faut une **dev build** :
 
@@ -365,26 +201,26 @@ cd ..
 npx expo run:ios
 ```
 
-**Résultat** : Safari pourra ouvrir directement `rnadvancedlabs://tp1-profile-card` ! 🎉
+**Résultat** : Safari pourra ouvrir directement `rnadvancedlabs://tp1-profile-card` !
 
-### 📋 Tests de Deep Linking
+### Tests de Deep Linking
 
-#### 🧊 **Test 1 : App fermée (Cold Start)**
+#### Test 1 : App fermée (Cold Start)
 - **Action** : Ouvrir `rnadvancedlabs://detail/42` depuis Safari
 - **Résultat attendu** : L'app se lance et affiche directement l'écran de détail avec ID=42
 - **Résultat obtenu** : ✅ L'app s'ouvre sur l'écran `[id].tsx` avec `id=42`
 
-#### 🔄 **Test 2 : App en arrière-plan (Warm)**
+#### Test 2 : App en arrière-plan (Warm)
 - **Action** : App minimisée, puis ouvrir `rnadvancedlabs://tp1-profile-card`
 - **Résultat attendu** : L'app revient au premier plan sur l'onglet Profile Card
 - **Résultat obtenu** : ✅ Navigation directe vers ProfileCard
 
-#### ⚡ **Test 3 : App déjà ouverte (Hot)**
+#### Test 3 : App déjà ouverte (Hot)
 - **Action** : App ouverte sur Accueil, puis ouvrir `rnadvancedlabs://detail/123`
 - **Résultat attendu** : Navigation vers l'écran de détail avec ID=123
 - **Résultat obtenu** : ✅ Navigation instantanée vers Detail avec le nouvel ID
 
-### 🔗 Liens disponibles
+### Liens disponibles
 
 ```bash
 # Navigation principale
@@ -406,7 +242,7 @@ rnadvancedlabs://tp3-forms/formik            → Formulaire Formik + Yup
 rnadvancedlabs://tp3-forms/rhf               → Formulaire RHF + Zod
 ```
 
-### 🛠️ Implémentation technique
+### Implémentation technique
 
 **Composants clés :**
 - `components/deep-link-handler.tsx` : Gestionnaire principal des liens entrants
@@ -414,14 +250,14 @@ rnadvancedlabs://tp3-forms/rhf               → Formulaire RHF + Zod
 - `hooks/use-route-persistence.ts` : Sauvegarde automatique des routes
 
 **Fonctionnalités :**
-- ✅ Parsing automatique des URLs (exp://, rnadvancedlabs://, https://)
-- ✅ Navigation sécurisée avec gestion d'erreurs
-- ✅ Validation des paramètres avant navigation
-- ✅ Logs détaillés pour le débogage
+- Parsing automatique des URLs (exp://, rnadvancedlabs://, https://)
+- Navigation sécurisée avec gestion d'erreurs
+- Validation des paramètres avant navigation
+- Logs détaillés pour le débogage
 
-## 🔙 Bouton Retour Natif iOS
+## Bouton Retour Natif iOS
 
-### 🎯 **Configuration**
+### Configuration
 
 L'application utilise le **Native Stack Navigator** d'Expo Router pour bénéficier du bouton retour natif iOS avec toutes ses fonctionnalités.
 
@@ -432,21 +268,21 @@ app/(main)/_layout.tsx    # Stack Navigator avec options natives
 └── detail/[id].tsx       # Écran avec bouton retour natif
 ```
 
-### ✨ **Fonctionnalités natives iOS**
+### Fonctionnalités natives iOS
 
-- ✅ **Bouton chevron natif** : Icône iOS officielle sans texte (`headerBackButtonDisplayMode: "minimal"`)
-- ✅ **Geste "liquid"** : Glissement interactif depuis le bord gauche de l'écran
-- ✅ **Animation fluide** : Transition native iOS entre les écrans
-- ✅ **Haptic feedback** : Retour haptique lors de l'interaction
+- **Bouton chevron natif** : Icône iOS officielle sans texte (`headerBackButtonDisplayMode: "minimal"`)
+- **Geste "liquid"** : Glissement interactif depuis le bord gauche de l'écran
+- **Animation fluide** : Transition native iOS entre les écrans
+- **Haptic feedback** : Retour haptique lors de l'interaction
 
-### 🎮 **Utilisation**
+### Utilisation
 
 1. **Navigation vers Détail** : Depuis Accueil ou Profil → "Voir Détail (ID: 42)"
 2. **Retour par bouton** : Appuyer sur le chevron en haut à gauche
 3. **Retour par geste** : Glisser depuis le bord gauche vers la droite
 4. **Retour programmatique** : `router.back()` en cas d'erreur
 
-### ⚙️ **Configuration technique**
+### Configuration technique
 
 ```typescript
 // app/(main)/_layout.tsx
@@ -467,45 +303,54 @@ app/(main)/_layout.tsx    # Stack Navigator avec options natives
 </Stack>
 ```
 
-### 📱 **Comportement UX**
+### Comportement UX
 
 - **TabBar masquée** : Sur l'écran Détail, seul le header Stack est visible
 - **TabBar visible** : Sur Accueil et Profil, les onglets restent accessibles
 - **Navigation cohérente** : Le retour ramène toujours vers l'onglet d'origine
 
+## Technologies utilisées
 
-## 🛠️ Technologies utilisées
-
-### 📦 **Packages principaux**
+### Packages principaux
 - **React Native** avec Expo SDK 54
 - **TypeScript** pour la sécurité de type
 - **Expo Router 6.0.4** pour la navigation file-based
 - **@react-native-async-storage/async-storage** pour la persistance
 - **@expo/vector-icons** pour les icônes des onglets
 
-### 🧩 **Hooks et utilitaires**
+### Hooks et utilitaires
 - **React Hooks** (useState, useRef, useEffect, useCallback)
 - **Expo Router hooks** (useLocalSearchParams, useRouter, useNavigation)
 - **Custom hooks** pour la persistance et la gestion des thèmes
 
-### 🎨 **UI et UX**
+### UI et UX
 - **Safe Area Context** pour la gestion des zones sûres
 - **React Native Screens** pour l'optimisation native
 - **Haptic Feedback** pour les interactions tactiles
 - **Animations et transitions** fluides
 
----
+## Utilisation
 
-## Récapitulatif des TP
+```bash
+# Installation des dépendances
+npm install
 
-### **Objectifs pédagogiques globaux atteints**
+# Démarrage
+npm start
+```
 
-| TP | Thème | Objectifs clés | Technologies |
-|----|-------|----------------|-------------|
-| **TP1** | Composants interactifs | État local, timers, animations | React Hooks, StyleSheet |
-| **TP2** | Navigation avancée | File-based routing, deep linking | Expo Router, AsyncStorage |
-| **TP3** | Formulaires avancés | Validation, performance, comparaison | Formik+Yup vs RHF+Zod |
+## Dépendances clés
 
+- `expo-router` : Navigation file-based
+- `@react-native-async-storage/async-storage` : Persistance locale
+- `@expo/vector-icons` : Icônes pour les onglets
+
+## Test de la persistance
+
+1. Naviguez vers "Profile Card" puis "Voir Détail (ID: 42)"
+2. Fermez complètement l'application
+3. Relancez → Vous devriez être sur l'écran de détail
+4. Le bouton retour fonctionne pour revenir à l'accueil
 
 ## Ressources et documentation
 
@@ -515,8 +360,6 @@ app/(main)/_layout.tsx    # Stack Navigator avec options natives
 - [Deep Linking Guide](https://docs.expo.dev/guides/linking/)
 - [AsyncStorage Documentation](https://react-native-async-storage.github.io/async-storage/)
 - [Communauté Discord Expo](https://chat.expo.dev)
-
----
 
 ## Commandes utiles
 
@@ -535,5 +378,819 @@ npx expo run:android         # Build et run Android
 npx expo install --fix       # Corriger les versions des packages
 npx react-devtools           # Outils de développement React
 ```
+
+---
+
+## Travaux Pratiques
+
+### TP1 - Profile Card Screen
+
+#### Localisation
+[`app/(main)/(tabs)/tp1-profile-card.tsx`](./app/(main)/(tabs)/tp1-profile-card.tsx)
+
+#### Description
+Écran de carte de profil interactif comprenant :
+- **Affichage profil** : Photo, nom, rôle utilisateur
+- **Follow/Unfollow** : Système interactif avec styles dynamiques
+- **Timer manuel** : Contrôles start/reset avec état local
+- **Auto-increment** : Compteur de followers (toutes les 5 secondes)
+- **Design moderne** : Responsive avec effets d'ombre et animations
+
+#### Objectifs pédagogiques
+- [x] État local avec `useState` et `useRef`
+- [x] Gestion des timers et intervalles
+- [x] Styles dynamiques et animations
+- [x] Design responsive et moderne
+
+#### Status 
+**Terminé** (Tag: `tp1-done`)
+
+---
+
+### TP2 - Navigation, Persistance & Deep Linking
+
+#### Localisation
+Architecture complète `app/` avec Expo Router
+
+#### Description
+- **Navigation multi-écrans** avec Expo Router (file-based routing)
+- **Architecture Stack + Tabs** avec layouts imbriqués
+- **Paramètres dynamiques** avec validation robuste
+- **Persistance navigation** (retour à la dernière page)
+- **Deep linking complet** (cold/warm/hot start)
+- **Bouton retour natif** iOS avec geste "liquid"
+
+#### Objectifs pédagogiques
+- [x] Architecture file-based routing avec Expo Router
+- [x] Navigation par onglets et stack imbriqués
+- [x] Passage de paramètres avec validation
+- [x] Persistance de l'état de navigation
+- [x] Deep linking complet (cold/warm/hot)
+- [x] Gestion d'erreurs et écrans 404
+- [x] Architecture propre avec un seul layout racine
+- [x] Bouton retour natif iOS avec geste "liquid" interactif
+
+#### Status
+**Terminé** (Tag: `tp2-done`)
+
+#### Navigation et Deep Linking
+
+##### Table des Routes
+
+| Route | Description | Type | Navigation |
+|-------|-------------|------|------------|
+| `/` | Point d'entrée avec persistance | Redirect | → `/(main)/(tabs)/home` |
+| `/(main)/(tabs)/home` | Page d'accueil avec liens vers TP3/TP4 | Tab | Onglet "Accueil" |
+| `/(main)/(tabs)/tp1-profile-card` | Carte de profil interactive (TP1) | Tab | Onglet "Profil" |
+| `/(main)/(tabs)/tp3-forms` | Vue d'ensemble des formulaires | Tab | Onglet "Formulaires" |
+| `/(main)/(tabs)/tp3-forms/formik` | Formulaire Formik + Yup | Stack | Accès direct en 2 taps |
+| `/(main)/(tabs)/tp3-forms/rhf` | Formulaire RHF + Zod | Stack | Accès direct en 2 taps |
+| `/(main)/detail/[id]` | Page de détail avec bouton retour natif | Stack | Header iOS avec geste "liquid" |
+| `/(main)/(tabs)/tp4-robots` | Liste CRUD robots (TP4) | Tab/Stack | Liste + accès Create/Edit |
+| `/(main)/(tabs)/tp4-robots/create` | Création d'un robot | Stack | Présentation "card" |
+| `/(main)/(tabs)/tp4-robots/edit/[id]` | Édition d'un robot | Stack | Présentation "card" |
+
+##### Deep Links disponibles
+
+```bash
+# Navigation principale
+rnadvancedlabs://                    → Page d'accueil
+rnadvancedlabs://tp1-profile-card    → Profile Card  
+
+# Navigation avec paramètres
+rnadvancedlabs://detail/42           → Écran de détail (ID: 42)
+rnadvancedlabs://detail/123          → Écran de détail (ID: 123)
+
+# Navigation TP3 - Formulaires
+rnadvancedlabs://tp3-forms           → Vue d'ensemble des formulaires
+rnadvancedlabs://tp3-forms/formik    → Formulaire Formik + Yup
+rnadvancedlabs://tp3-forms/rhf       → Formulaire RHF + Zod
+
+# Navigation TP4 - Robots
+rnadvancedlabs://tp4-robots                  → Liste des robots
+rnadvancedlabs://tp4-robots/create           → Création d'un robot
+rnadvancedlabs://tp4-robots/edit/550e-...    → Édition d'un robot par ID
+
+# Gestion d'erreurs
+rnadvancedlabs://detail/             → Écran 404 (ID manquant)
+```
+
+#### Bouton Retour Natif iOS
+
+- **Bouton chevron natif** : Icône iOS officielle sans texte
+- **Geste "liquid"** : Glissement interactif depuis le bord gauche
+- **Animation fluide** : Transition native iOS entre les écrans
+- **Haptic feedback** : Retour haptique lors de l'interaction
+
+---
+
+### TP3 - Formulaires avancés avec validation temps réel
+
+#### Localisation
+`app/(main)/(tabs)/tp3-forms/` avec arborescence structurée
+
+#### Description
+- **Deux implémentations** de formulaires d'inscription identiques
+- **Formik + Yup** : Gestion classique avec `useField` et validation Yup
+- **React Hook Form + Zod** : Performance optimisée avec `Controller` et validation Zod
+- **Validation temps réel** avec messages d'erreur dynamiques
+- **Design moderne** avec placeholders personnalisés et animations
+- **Navigation croisée** pour comparer les deux approches
+- **Submit bloqué** si formulaire invalide ou non modifié
+- **Instrumentation** et mesure des performances avec logs
+
+#### Objectifs pédagogiques
+- [x] Deux implémentations identiques (Formik + Yup vs RHF + Zod)
+- [x] Arborescence respectée avec validation/ et components/ séparés
+- [x] Navigation directe en 2 taps maximum depuis l'accueil
+- [x] Liens croisés Formik ⇄ RHF pour comparaison rapide
+- [x] Validation temps réel avec messages d'erreur
+- [x] Submit bloqué si formulaire invalide ou non modifié
+- [x] Design moderne avec placeholders personnalisés
+- [x] Retour fonctionnel avec header natif
+- [x] Instrumentation et mesure des performances avec logs
+
+#### Status
+**Terminé** (Tag: `tp3-done`)
+
+#### Navigation TP3
+
+##### Accès direct en 2 taps maximum
+
+**Depuis l'écran d'accueil :**
+1. **Tap 1** : Bouton "TP3 – Formik" → `/(main)/(tabs)/tp3-forms/formik`
+2. **Tap 1** : Bouton "TP3 – RHF" → `/(main)/(tabs)/tp3-forms/rhf`
+
+**Depuis l'onglet Formulaires :**
+1. **Tap 1** : Onglet "Formulaires" → Vue d'ensemble
+2. **Tap 2** : Bouton vers Formik ou RHF
+
+##### Liens croisés
+
+Chaque écran de formulaire contient un bouton de navigation croisée :
+- **Formik** → Bouton "Basculer vers RHF + Zod"
+- **RHF** → Bouton "Basculer vers Formik + Yup"
+
+##### Retour fonctionnel
+
+- **Header natif** avec bouton retour iOS
+- **Geste liquid** depuis le bord gauche
+- **Navigation programmatique** avec `router.back()`
+- **Pile de navigation** préservée
+
+---
+
+---
+
+### TP4 - Zustand : CRUD "Robots"
+
+#### Objectifs réalisés
+
+- **Store global Zustand** avec persistance AsyncStorage
+- **CRUD complet** : Create, Read, Update, Delete
+- **Formulaire robuste** avec React Hook Form + Zod
+- **Navigation Expo Router** : liste → création/édition → retour
+- **Validation avancée** avec règles métier strictes
+
+#### Architecture implémentée
+
+```
+TP4 Robots
+├── store/robotsStore.ts          # Store Zustand avec persistance
+├── validation/robotSchema.ts      # Schéma Zod + types TypeScript
+├── components/robots/
+│   ├── RobotForm.tsx                 # Formulaire réutilisable (create/edit)
+│   └── RobotListItem.tsx            # Item de liste avec actions
+└── app/(main)/(tabs)/tp4-robots/
+    ├── index.tsx                     # Liste des robots
+    ├── create.tsx                    # Création
+    ├── edit/[id].tsx                # Édition
+    └── _layout.tsx                  # Layout Stack
+```
+
+#### Modèle Robot
+
+```typescript
+interface Robot {
+  id: string;              // UUID généré automatiquement
+  name: string;            // Min 2 char, unique dans la collection
+  label: string;           // Min 3 char, description
+  year: number;            // Entre 1950 et année courante
+  type: RobotType;         // industrial | service | medical | educational | other
+  createdAt: Date;         // Timestamp de création
+  updatedAt: Date;         // Timestamp de dernière modification
+}
+```
+
+#### Fonctionnalités UX
+
+##### Liste des robots
+- **Tri automatique** par nom (ordre alphabétique)
+- **Badges colorés** par type avec icônes
+- **Actions rapides** : Modifier / Supprimer
+- **Mise à jour temps réel** après CRUD
+- **FAB (Floating Action Button)** pour création
+- **État vide** avec CTA de création
+
+##### Formulaire (Create/Edit)
+- **KeyboardAvoidingView** pour éviter le masquage
+- **Navigation fluide** entre champs (`returnKeyType`)
+- **Validation temps réel** avec messages d'erreur
+- **Submit désactivé** si formulaire invalide
+- **Feedback haptique** (succès/erreur)
+- **Picker natif** pour sélection du type
+
+##### Validation métier
+- **Unicité du nom** (refus des doublons)
+- **Année valide** (1950 ≤ year ≤ année courante)
+- **Longueurs min/max** respectées
+- **Types énumérés** avec labels français
+
+#### Choix techniques
+
+##### Zustand vs Redux
+**Pourquoi Zustand ?**
+- **Simplicité** : Moins de boilerplate que Redux
+- **Performance** : Sélecteurs optimisés pour éviter les re-renders
+- **TypeScript** : Support natif excellent
+- **Persistance** : Middleware intégré avec AsyncStorage
+- **Devtools** : Compatible Redux DevTools
+
+##### React Hook Form + Zod vs Formik + Yup
+**Pourquoi RHF + Zod ?**
+- **Performance** : Moins de re-renders (uncontrolled forms)
+- **Bundle size** : Plus léger que Formik
+- **TypeScript** : Inférence de types automatique avec Zod
+- **Validation** : Schema-first avec Zod plus moderne
+- **Réactivité** : Validation temps réel fluide
+
+#### Store Zustand - Patterns avancés
+
+```typescript
+// Sélecteurs optimisés pour éviter les re-renders
+export const useRobots = () => useRobotsStore((state) => state.robots);
+export const useRobotsSorted = () => useRobotsStore((state) => state.getRobotsSorted());
+
+// Actions isolées
+export const useRobotsActions = () => useRobotsStore((state) => ({
+  create: state.create,
+  update: state.update,
+  remove: state.remove,
+  getById: state.getById,
+}));
+```
+
+#### Persistance & Performance
+
+- **AsyncStorage** : Sauvegarde automatique des robots
+- **Partialisation** : Seules les données métier sont persistées (pas l'UI state)
+- **Désérialisation** : Reconstruction des objets Date au reload
+- **Sélecteurs** : Évitent les re-renders inutiles des composants
+
+#### Tests & Validation
+
+##### Règles métier testables
+- Création d'un robot avec nom existant → Erreur
+- Année 1949 ou 2026 → Erreur de validation
+- Nom < 2 caractères → Erreur de validation
+- Mise à jour avec même nom → Autorisé
+- Suppression → Confirmation utilisateur requise
+
+#### Routes & Navigation
+
+```
+/tp4-robots           → Liste des robots
+/tp4-robots/create    → Création d'un robot
+/tp4-robots/edit/[id] → Édition d'un robot
+```
+
+**Navigation Stack configurée avec :**
+- Bouton retour natif iOS/Android
+- Gestes de navigation
+- Headers personnalisés
+- Présentation card pour create/edit
+
+#### Objectifs pédagogiques réalisés
+
+Ce TP implémente une **gestion d'état centralisée** avec **Zustand** pour gérer une collection de robots, en respectant les principes du **Module 6** du cours (Gestion d'État Centralisée).
+
+- **Store global Zustand** avec slice dédiée aux robots
+- **CRUD complet** : Create, Read, Update, Delete avec persistance
+- **Sélecteurs optimisés** pour éviter les re-renders inutiles
+- **Persistance AsyncStorage** : les robots survivent au redémarrage
+- **Formulaires performants** avec React Hook Form + Zod
+- **Validation métier stricte** avec règles d'unicité
+
+#### Architecture Zustand : Store centralisé
+
+##### Concept fondamental
+Selon le cours, Zustand permet de créer un **store global** avec des **slices par domaine**. Notre slice `robots` centralise tout l'état et la logique métier liée aux robots.
+
+```typescript
+// store/robotsStore.ts
+interface RobotsState {
+  robots: Robot[];        // Collection complète des robots
+  selectedId?: string;    // Robot actuellement sélectionné (optionnel)
+}
+
+interface RobotsActions {
+  // CRUD Operations
+  create: (robotInput: RobotInput) => Promise<Result>;
+  update: (id: string, robotInput: RobotInput) => Promise<Result>;
+  remove: (id: string) => boolean;
+  getById: (id: string) => Robot | undefined;
+  
+  // Utilitaires
+  isNameUnique: (name: string, excludeId?: string) => boolean;
+  getRobotsSorted: () => Robot[];
+}
+```
+
+##### Store avec persistance automatique
+
+```typescript
+export const useRobotsStore = create<RobotsStore>()(
+  persist(
+    (set, get) => ({
+      // État initial
+      robots: [],
+      selectedId: undefined,
+
+      // Actions CRUD avec logique métier
+      create: async (robotInput: RobotInput) => {
+        // 1. Vérification unicité du nom
+        if (!state.isNameUnique(robotInput.name)) {
+          return { success: false, error: "Nom déjà existant" };
+        }
+
+        // 2. Génération UUID + timestamps
+        const newRobot: Robot = {
+          id: generateId(),
+          ...robotInput,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+
+        // 3. Mise à jour immutable du state
+        set((state) => ({
+          robots: [...state.robots, newRobot],
+        }));
+
+        return { success: true, robot: newRobot };
+      },
+      
+      // Autres actions...
+    }),
+    {
+      name: 'robots-storage',                    // Clé AsyncStorage
+      storage: createJSONStorage(() => AsyncStorage), // Persistance locale
+      partialize: (state) => ({ robots: state.robots }), // Seules les données métier
+      
+      // Désérialisation des dates après rechargement
+      onRehydrateStorage: () => (state) => {
+        if (state?.robots) {
+          state.robots = state.robots.map((robot: any) => ({
+            ...robot,
+            createdAt: new Date(robot.createdAt),
+            updatedAt: new Date(robot.updatedAt),
+          }));
+        }
+      },
+    }
+  )
+);
+```
+
+#### Stockage et persistance des robots
+
+- En mémoire: `robots: Robot[]` dans le store Zustand.
+- Persistance locale: AsyncStorage (clé `robots-storage`) via le middleware `persist`.
+- Désérialisation: les champs `Date` sont reconstruits au rechargement.
+
+Cycle: lancement → hydratation depuis AsyncStorage → UI réactive; chaque action CRUD déclenche une sauvegarde automatique.
+
+#### Sélecteurs optimisés : Performance avant tout
+
+##### Problème des re-renders
+Sans sélecteurs, chaque modification du store re-render tous les composants abonnés.
+
+##### Solution : Sélecteurs granulaires
+
+```typescript
+// Mauvais : re-render à chaque changement du store
+const store = useRobotsStore();
+
+// Bon : re-render uniquement si la liste change
+const robots = useRobots();
+
+// Encore mieux : hooks spécialisés
+export const useRobots = () => useRobotsStore((state) => state.robots);
+export const useRobotsSorted = () => useRobotsStore((state) => state.getRobotsSorted());
+export const useCreateRobot = () => useRobotsStore((state) => state.create);
+export const useRemoveRobot = () => useRobotsStore((state) => state.remove);
+```
+
+##### Usage dans les composants
+
+```typescript
+// Composant Liste - Ne re-render que si la liste change
+function RobotsListScreen() {
+  const robots = useRobotsSorted();  // Sélecteur optimisé
+  const remove = useRemoveRobot();   // Action isolée
+  
+  // Ce composant ne re-render PAS si selectedId change
+}
+
+// Composant Création - Ne re-render que si create change (jamais)
+function CreateRobotScreen() {
+  const create = useCreateRobot();   // Action stable
+  
+  // Composant très performant, quasiment aucun re-render
+}
+```
+
+#### Règles métier et validation
+
+##### Modèle Robot complet
+
+```typescript
+interface Robot {
+  // Identité
+  id: string;              // UUID v4 généré automatiquement
+  
+  // Données métier
+  name: string;            // Min 2 char, unique dans la collection
+  label: string;           // Min 3 char, description libre
+  year: number;            // Entier entre 1950 et année courante
+  type: RobotType;         // Enum: industrial|service|medical|educational|other
+  
+  // Métadonnées
+  createdAt: Date;         // Timestamp de création
+  updatedAt: Date;         // Timestamp de dernière modification
+}
+```
+
+##### Validation Zod (Schema-first)
+
+```typescript
+export const robotSchema = z.object({
+  name: z.string()
+    .min(2, 'Le nom doit contenir au moins 2 caractères')
+    .max(50, 'Le nom ne peut pas dépasser 50 caractères'),
+  
+  label: z.string()
+    .min(3, 'Le libellé doit contenir au moins 3 caractères')
+    .max(100, 'Le libellé ne peut pas dépasser 100 caractères'),
+  
+  year: z.number()
+    .int('L\'année doit être un nombre entier')
+    .min(1950, 'L\'année doit être supérieure ou égale à 1950')
+    .max(new Date().getFullYear(), 'L\'année ne peut pas être future'),
+  
+  type: z.enum(['industrial', 'service', 'medical', 'educational', 'other']),
+});
+```
+
+##### Règles métier dans le store
+
+```typescript
+// Vérification d'unicité côté store
+isNameUnique: (name: string, excludeId?: string) => {
+  const robots = get().robots;
+  const normalizedName = name.toLowerCase().trim();
+  
+  return !robots.some((robot) => 
+    robot.id !== excludeId && 
+    robot.name.toLowerCase().trim() === normalizedName
+  );
+},
+
+// Application lors de la création
+create: async (robotInput: RobotInput) => {
+  if (!state.isNameUnique(robotInput.name)) {
+    return {
+      success: false,
+      error: `Un robot avec le nom "${robotInput.name}" existe déjà`,
+    };
+  }
+  // ... suite de la logique
+}
+```
+
+#### Avantages de cette architecture
+
+##### Séparation des responsabilités
+- **Store** : État global + logique métier pure
+- **Composants** : Interface utilisateur + interactions
+- **Validation** : Schémas Zod isolés et réutilisables
+
+##### Performance optimisée
+- Sélecteurs granulaires → re-renders minimisés
+- Actions stables → pas de re-création à chaque render
+- Zustand natif → pas de boilerplate Redux
+
+##### Persistance transparente
+- Sauvegarde automatique à chaque modification
+- Restauration complète au redémarrage
+- Gestion des types complexes (Date, objets imbriqués)
+
+##### Testabilité maximale
+- Store isolé testable unitairement
+- Actions pures sans effets de bord
+- Mocking facile pour les tests d'interface
+
+#### Interface utilisateur réactive
+
+##### Mise à jour temps réel
+Grâce à Zustand, toute modification du store met à jour automatiquement tous les composants abonnés :
+
+```
+Utilisateur crée un robot
+    ↓
+Action create() dans le store
+    ↓
+Mise à jour immutable de robots[]
+    ↓
+Re-render automatique de RobotsListScreen
+    ↓
+Nouveau robot visible instantanément
+```
+
+##### États de l'interface
+
+```typescript
+// Liste vide → État d'accueil avec CTA
+if (robots.length === 0) {
+  return <EmptyState onCreateFirst={handleCreate} />;
+}
+
+// Liste peuplée → FAB + liste triée
+return (
+  <>
+    <FlatList data={robotsSorted} />
+    <FloatingActionButton onPress={handleCreate} />
+  </>
+);
+```
+
+#### Métriques et monitoring
+
+##### Instrumentation du store
+
+```typescript
+create: async (robotInput: RobotInput) => {
+  console.log('Création robot:', robotInput.name);
+  
+  const result = await /* logique création */;
+  
+  if (result.success) {
+    console.log('Robot créé avec succès:', result.robot.id);
+  } else {
+    console.log('Échec création:', result.error);
+  }
+  
+  return result;
+}
+```
+
+##### Statistiques automatiques
+
+```typescript
+// Computed values dans le store
+getRobotStats: () => {
+  const robots = get().robots;
+  return {
+    total: robots.length,
+    byType: robots.reduce((acc, robot) => {
+      acc[robot.type] = (acc[robot.type] || 0) + 1;
+      return acc;
+    }, {}),
+    oldestYear: Math.min(...robots.map(r => r.year)),
+    newestYear: Math.max(...robots.map(r => r.year)),
+  };
+}
+```
+
+#### Pattern Reducer intégré dans Zustand
+
+##### Actions = Reducers modernes
+Contrairement à `useState` simple, notre store Zustand utilise le **pattern reducer** via la fonction `set()`. Chaque action fonctionne comme un reducer traditionnel mais avec une syntaxe plus moderne :
+
+```typescript
+// Pattern Reducer dans Zustand
+create: async (robotInput: RobotInput) => {
+  // Logique métier (validation, génération ID...)
+  const newRobot = { id: generateId(), ...robotInput, createdAt: new Date() };
+  
+  // Reducer : State + Action → Nouveau State (immutable)
+  set((currentState) => ({
+    robots: [...currentState.robots, newRobot],  // Nouvel état immutable
+  }));
+},
+
+remove: (id: string) => {
+  // Reducer : filtre immutable du tableau
+  set((currentState) => ({
+    robots: currentState.robots.filter(robot => robot.id !== id),
+    selectedId: currentState.selectedId === id ? undefined : currentState.selectedId,
+  }));
+},
+```
+
+##### Comparaison avec useReducer traditionnel
+
+```typescript
+// Pattern useReducer classique (verbeux)
+const robotsReducer = (state, action) => {
+  switch (action.type) {
+    case 'ADD_ROBOT':
+      return { ...state, robots: [...state.robots, action.payload] };
+    case 'REMOVE_ROBOT':
+      return { ...state, robots: state.robots.filter(r => r.id !== action.payload) };
+    case 'UPDATE_ROBOT':
+      return { ...state, robots: state.robots.map(r => 
+        r.id === action.payload.id ? { ...r, ...action.payload.data } : r
+      )};
+    default:
+      return state;
+  }
+};
+
+// Pattern Zustand (direct et typé)
+const store = create((set, get) => ({
+  robots: [],
+  addRobot: (robot) => set(state => ({ robots: [...state.robots, robot] })),
+  removeRobot: (id) => set(state => ({ robots: state.robots.filter(r => r.id !== id) })),
+  updateRobot: (id, data) => set(state => ({ 
+    robots: state.robots.map(r => r.id === id ? { ...r, ...data } : r)
+  })),
+}));
+```
+
+#### Mapping Store ↔ Composants : Réactivité automatique
+
+##### Flux de données complet
+
+```
+Composant déclenche une action
+    ↓
+Action modifie le store via set() [Pattern Reducer]
+    ↓
+Nouveau state immutable créé
+    ↓
+Zustand notifie tous les sélecteurs abonnés
+    ↓
+Composants concernés re-render automatiquement
+    ↓
+Interface mise à jour en temps réel
+```
+
+##### Sélecteurs = Mapping granulaire du State
+
+```typescript
+// Chaque sélecteur mappe une partie spécifique du store
+export const useRobots = () => useRobotsStore((state) => state.robots);
+export const useRobotCount = () => useRobotsStore((state) => state.robots.length);
+export const useRobotById = (id: string) => useRobotsStore((state) => 
+  state.robots.find(robot => robot.id === id)
+);
+
+// Usage dans les composants
+function RobotsListScreen() {
+  const robots = useRobots();        // Re-render si robots[] change
+  const remove = useRemoveRobot();   // Action stable (pas de re-render)
+  
+  // Mapping automatique : robots[] → Interface utilisateur
+  return (
+    <FlatList 
+      data={robots}  // Données mappées directement du store
+      renderItem={({ item }) => (
+        <RobotItem robot={item} onDelete={() => remove(item.id)} />
+      )}
+    />
+  );
+}
+```
+
+##### Re-renders optimisés par sélecteur
+
+```typescript
+// Composant optimisé : ne re-render QUE si sa partie du state change
+function RobotCounter() {
+  const count = useRobotsStore((state) => state.robots.length);
+  // Re-render SEULEMENT si le nombre total change
+  // PAS si un robot individuel est modifié
+  return <Text>Total: {count} robots</Text>;
+}
+
+function RobotDetails({ robotId }) {
+  const robot = useRobotsStore((state) => 
+    state.robots.find(r => r.id === robotId)
+  );
+  // Re-render SEULEMENT si CE robot spécifique change
+  // PAS si d'autres robots sont modifiés
+  return <Text>{robot?.name}</Text>;
+}
+
+// Anti-pattern : re-render à chaque changement du store
+function BadComponent() {
+  const store = useRobotsStore();  // Re-render pour TOUT changement
+  return <Text>{store.robots.length}</Text>;
+}
+```
+
+#### Immutabilité et Performance
+
+##### Zustand garantit l'immutabilité
+
+```typescript
+// Correct : création d'un nouvel état
+set((state) => ({
+  robots: [...state.robots, newRobot],  // Nouveau tableau
+}));
+
+set((state) => ({
+  robots: state.robots.map(robot =>     // Nouveau tableau avec objets modifiés
+    robot.id === id ? { ...robot, ...updates } : robot
+  ),
+}));
+
+// Interdit : mutation directe (Zustand l'empêche)
+set((state) => {
+  state.robots.push(newRobot);  // Mutation du tableau existant
+  return state;
+});
+```
+
+##### Détection des changements optimisée
+
+```typescript
+// Zustand utilise Object.is() pour détecter les changements
+const previousRobots = [robot1, robot2];
+const newRobots = [...previousRobots, robot3];  // Nouvelle référence
+
+// Zustand détecte : previousRobots !== newRobots → re-render nécessaire
+// Si pas de changement : même référence → pas de re-render
+```
+
+#### Avantages du Pattern Reducer + Mapping Zustand
+
+##### vs useState seul :
+- **État complexe** : Gère facilement des objets imbriqués et des collections
+- **Actions nommées** : `create()`, `update()`, `remove()` plus claires que `setRobots()`
+- **Logique centralisée** : Validation et règles métier dans le store
+- **Immutabilité forcée** : Pas de mutations accidentelles
+
+##### vs useReducer traditionnel :
+- **Syntaxe directe** : Pas de switch/case verbeux
+- **TypeScript natif** : Inférence automatique des types
+- **Actions async** : Support natif des opérations asynchrones
+- **Persistance intégrée** : Middleware persist transparent
+
+##### vs Redux :
+- **Moins de boilerplate** : Pas d'actions creators, reducers séparés
+- **Store unique** : Une seule fonction `create()` pour tout définir
+- **Performance native** : Sélecteurs optimisés par défaut
+- **DevTools** : Compatible Redux DevTools sans configuration
+
+#### Exemple complet : Cycle de vie d'une modification
+
+```typescript
+// 1. Utilisateur clique sur "Supprimer" dans l'interface
+<TouchableOpacity onPress={() => handleDelete(robot.id)}>
+  <Text>Supprimer</Text>
+</TouchableOpacity>
+
+// 2. Composant appelle l'action du store
+const handleDelete = (id: string) => {
+  remove(id);  // Action Zustand
+};
+
+// 3. Store exécute le "reducer" via set()
+remove: (id: string) => {
+  const robot = get().getById(id);
+  
+  set((state) => ({  // Pattern Reducer
+    robots: state.robots.filter(r => r.id !== id),           // Nouveau tableau
+    selectedId: state.selectedId === id ? undefined : state.selectedId,
+  }));
+  
+  console.log('Robot supprimé:', robot?.name);
+  return true;
+},
+
+// 4. Zustand notifie tous les sélecteurs abonnés
+// - useRobots() détecte le changement de robots[]
+// - useRobotCount() détecte le changement du nombre
+// - useSelectedRobot() détecte le changement de selectedId
+
+// 5. Composants concernés re-render automatiquement
+function RobotsListScreen() {
+  const robots = useRobots();  // ← Nouveau tableau sans le robot supprimé
+  // Interface mise à jour automatiquement !
+}
+```
+
+Cette architecture combine le **meilleur des patterns reducer** (immutabilité, actions nommées, logique centralisée) avec la **simplicité de Zustand** (syntaxe moderne, TypeScript natif, performance optimisée) pour offrir une **gestion d'état moderne, performante et maintenable**.
 
 ---

--- a/app/(main)/(tabs)/_layout.tsx
+++ b/app/(main)/(tabs)/_layout.tsx
@@ -39,6 +39,16 @@ export default function TabsLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="tp4-robots"
+        options={{
+          title: "Robots",
+          headerShown: false, // Le stack gère les headers
+          tabBarIcon: ({ color }) => (
+            <IconSymbol name="gear.circle.fill" color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(main)/(tabs)/home.tsx
+++ b/app/(main)/(tabs)/home.tsx
@@ -4,10 +4,10 @@ import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-nati
 
 export default function HomeScreen() {
   useEffect(() => {
-    console.log("🏠 HomeScreen - Écran d'accueil monté");
+    // console.log("🏠 HomeScreen - Écran d'accueil monté");
   }, []);
 
-  console.log("🔄 HomeScreen - Rendu de la page d'accueil");
+  // console.log("🔄 HomeScreen - Rendu de la page d'accueil");
 
   return (
     <ScrollView 
@@ -19,7 +19,7 @@ export default function HomeScreen() {
       <Text style={styles.subtitle}>Laboratoires avancés React Native</Text>
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>Navigation TP2</Text>
+        <Text style={styles.cardTitle}>TP2 - Navigation</Text>
         <Text style={styles.cardDescription}>
           Structure de navigation avec Stack et Tabs configurée avec succès !
         </Text>
@@ -64,6 +64,19 @@ export default function HomeScreen() {
         <Link href="/(main)/(tabs)/tp3-forms" asChild>
           <TouchableOpacity style={styles.formsOverviewButton}>
             <Text style={styles.detailButtonText}>Vue d'ensemble</Text>
+          </TouchableOpacity>
+        </Link>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>TP4 - Gestion des Robots</Text>
+        <Text style={styles.cardDescription}>
+          CRUD complet avec Zustand : créer, lister, modifier et supprimer des robots
+        </Text>
+
+        <Link href="/(main)/(tabs)/tp4-robots" asChild>
+          <TouchableOpacity style={styles.robotsButton}>
+            <Text style={styles.detailButtonText}>TP4 – Robots</Text>
           </TouchableOpacity>
         </Link>
       </View>
@@ -154,6 +167,13 @@ const styles = StyleSheet.create({
   },
   formsOverviewButton: {
     backgroundColor: "#8b5cf6",
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  robotsButton: {
+    backgroundColor: "#f59e0b",
     paddingHorizontal: 20,
     paddingVertical: 12,
     borderRadius: 8,

--- a/app/(main)/(tabs)/tp1-profile-card.tsx
+++ b/app/(main)/(tabs)/tp1-profile-card.tsx
@@ -15,7 +15,7 @@ export default function ProfileCard() {
   const followersRef = useRef<number | null>(null);
 
   useEffect(() => {
-    console.log("👤 ProfileCard - Écran Profile Card monté");
+    // console.log("👤 ProfileCard - Écran Profile Card monté");
   }, []);
 
   const handleFollow = () => {

--- a/app/(main)/(tabs)/tp3-forms/formik/components/_FormField.tsx
+++ b/app/(main)/(tabs)/tp3-forms/formik/components/_FormField.tsx
@@ -17,7 +17,7 @@ export const FormField = React.forwardRef<TextInput, FormFieldProps>(({
   // 📊 Instrumentation : Log des re-rendus par champ
   const renderCount = useRef(0);
   renderCount.current += 1;
-  console.log(`🔧 [Formik] FormField "${name}" - Rendu #${renderCount.current}`);
+  // console.log(`🔧 [Formik] FormField "${name}" - Rendu #${renderCount.current}`);
 
   const [field, meta, helpers] = useField(name);
   const hasError = meta.touched && meta.error;

--- a/app/(main)/(tabs)/tp3-forms/formik/index.tsx
+++ b/app/(main)/(tabs)/tp3-forms/formik/index.tsx
@@ -30,7 +30,7 @@ export default function FormikFormScreen() {
   // 📊 Instrumentation : Log des re-rendus du composant principal
   const renderCount = useRef(0);
   renderCount.current += 1;
-  console.log(`🔧 [Formik] Composant principal - Rendu #${renderCount.current}`);
+  // console.log(`🔧 [Formik] Composant principal - Rendu #${renderCount.current}`);
 
   // Références pour la navigation entre les champs
   const passwordRef = useRef<TextInput | null>(null);

--- a/app/(main)/(tabs)/tp3-forms/rhf/components/_FormField.tsx
+++ b/app/(main)/(tabs)/tp3-forms/rhf/components/_FormField.tsx
@@ -18,7 +18,7 @@ const FormField = React.forwardRef<TextInput, FormFieldProps>(({
   // 📊 Instrumentation : Log des re-rendus par champ
   const renderCount = useRef(0);
   renderCount.current += 1;
-  console.log(`⚡ [RHF] FormField "${name}" - Rendu #${renderCount.current}`);
+  // console.log(`⚡ [RHF] FormField "${name}" - Rendu #${renderCount.current}`);
 
   const { control, formState: { errors } } = useFormContext<RegistrationFormValues>();
   const error = errors[name];

--- a/app/(main)/(tabs)/tp3-forms/rhf/index.tsx
+++ b/app/(main)/(tabs)/tp3-forms/rhf/index.tsx
@@ -31,7 +31,7 @@ export default function RHFFormScreen() {
   // 📊 Instrumentation : Log des re-rendus du composant principal
   const renderCount = useRef(0);
   renderCount.current += 1;
-  console.log(`⚡ [RHF] Composant principal - Rendu #${renderCount.current}`);
+  // console.log(`⚡ [RHF] Composant principal - Rendu #${renderCount.current}`);
 
   // Références pour la navigation entre les champs
   const passwordRef = useRef<TextInput | null>(null);

--- a/app/(main)/(tabs)/tp4-robots/_layout.tsx
+++ b/app/(main)/(tabs)/tp4-robots/_layout.tsx
@@ -1,0 +1,40 @@
+import { Stack } from 'expo-router';
+
+export default function TP4RobotsLayout() {
+  return (
+    <Stack screenOptions={{
+      headerShown: true,
+      headerBackButtonDisplayMode: "minimal",
+      gestureEnabled: true,
+      headerStyle: {
+        backgroundColor: '#f9fafb',
+      },
+      headerTintColor: '#111827',
+      headerTitleStyle: {
+        fontWeight: '700',
+      },
+    }}>
+      <Stack.Screen 
+        name="index" 
+        options={{ 
+          title: 'Robots',
+          headerLeft: () => null, // Pas de bouton retour car accessible depuis les tabs
+        }} 
+      />
+      <Stack.Screen 
+        name="create" 
+        options={{ 
+          title: 'Nouveau robot',
+          presentation: 'card',
+        }} 
+      />
+      <Stack.Screen 
+        name="edit/[id]" 
+        options={{ 
+          title: 'Modifier le robot',
+          presentation: 'card',
+        }} 
+      />
+    </Stack>
+  );
+}

--- a/app/(main)/(tabs)/tp4-robots/create.tsx
+++ b/app/(main)/(tabs)/tp4-robots/create.tsx
@@ -1,0 +1,74 @@
+import * as Haptics from 'expo-haptics';
+import { useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import { Alert, StyleSheet, View } from 'react-native';
+import RobotForm from '../../../../components/robots/RobotForm';
+import { useCreateRobot } from '../../../../store/robotsStore';
+import type { RobotInput } from '../../../../validation/robotSchema';
+
+export default function CreateRobotScreen() {
+  const router = useRouter();
+  const create = useCreateRobot();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (data: RobotInput) => {
+    setIsLoading(true);
+    
+    try {
+      const result = await create(data);
+      
+      if (result.success) {
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        
+        // Show success message
+        Alert.alert(
+          'Succès !',
+          `Le robot "${data.name}" a été créé avec succès.`,
+          [
+            {
+              text: 'Continuer',
+              onPress: () => {
+                // Form is already reset in RobotForm component
+              }
+            },
+            {
+              text: 'Retour à la liste',
+              onPress: () => {
+                router.back();
+              }
+            }
+          ]
+        );
+        
+        return result;
+      } else {
+        return result;
+      }
+    } catch (error) {
+      console.error('Error creating robot:', error);
+      return {
+        success: false,
+        error: 'Une erreur inattendue est survenue lors de la création du robot.',
+      };
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <RobotForm
+        mode="create"
+        onSubmit={handleSubmit}
+        isLoading={isLoading}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f9fafb',
+  },
+});

--- a/app/(main)/(tabs)/tp4-robots/edit/[id].tsx
+++ b/app/(main)/(tabs)/tp4-robots/edit/[id].tsx
@@ -1,0 +1,140 @@
+import * as Haptics from 'expo-haptics';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useState } from 'react';
+import { Alert, StyleSheet, Text, View } from 'react-native';
+import RobotForm from '../../../../../components/robots/RobotForm';
+import { useGetRobotById, useUpdateRobot } from '../../../../../store/robotsStore';
+import type { Robot, RobotInput } from '../../../../../validation/robotSchema';
+
+export default function EditRobotScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const getById = useGetRobotById();
+  const update = useUpdateRobot();
+  const [robot, setRobot] = useState<Robot | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (id) {
+      const foundRobot = getById(id);
+      if (foundRobot) {
+        setRobot(foundRobot);
+      } else {
+        setNotFound(true);
+      }
+    }
+  }, [id, getById]);
+
+  const handleSubmit = async (data: RobotInput) => {
+    if (!robot) return { success: false, error: 'Robot non trouvé' };
+    
+    setIsLoading(true);
+    
+    try {
+      const result = await update(robot.id, data);
+      
+      if (result.success) {
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        
+        // Show success message and go back
+        Alert.alert(
+          'Succès !',
+          `Le robot "${data.name}" a été mis à jour avec succès.`,
+          [
+            {
+              text: 'Retour à la liste',
+              onPress: () => {
+                router.back();
+              }
+            }
+          ]
+        );
+        
+        return result;
+      } else {
+        return result;
+      }
+    } catch (error) {
+      console.error('Error updating robot:', error);
+      return {
+        success: false,
+        error: 'Une erreur inattendue est survenue lors de la mise à jour du robot.',
+      };
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (notFound) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorTitle}>Robot non trouvé</Text>
+        <Text style={styles.errorMessage}>
+          Le robot avec l'ID "{id}" n'existe pas ou a été supprimé.
+        </Text>
+      </View>
+    );
+  }
+
+  if (!robot) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text style={styles.loadingText}>Chargement...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <RobotForm
+        mode="edit"
+        initialValues={{
+          name: robot.name,
+          label: robot.label,
+          year: robot.year,
+          type: robot.type,
+        }}
+        onSubmit={handleSubmit}
+        isLoading={isLoading}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f9fafb',
+  },
+  errorContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    backgroundColor: '#f9fafb',
+  },
+  errorTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#ef4444',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  errorMessage: {
+    fontSize: 16,
+    color: '#6b7280',
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#f9fafb',
+  },
+  loadingText: {
+    fontSize: 18,
+    color: '#6b7280',
+  },
+});

--- a/app/(main)/(tabs)/tp4-robots/index.tsx
+++ b/app/(main)/(tabs)/tp4-robots/index.tsx
@@ -1,0 +1,186 @@
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { useRouter } from 'expo-router';
+import React, { useCallback } from 'react';
+import {
+    FlatList,
+    RefreshControl,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+import RobotListItem from '../../../../components/robots/RobotListItem';
+import { useRemoveRobot, useRobotsSorted } from '../../../../store/robotsStore';
+import type { Robot } from '../../../../validation/robotSchema';
+
+export default function RobotsListScreen() {
+  const router = useRouter();
+  const robots = useRobotsSorted();
+  const remove = useRemoveRobot();
+
+  const handleCreateRobot = async () => {
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    router.push('/tp4-robots/create' as any);
+  };
+
+  const handleDeleteRobot = useCallback(async (id: string) => {
+    const success = remove(id);
+    if (success) {
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    }
+  }, [remove]);
+
+  const renderRobotItem = useCallback(({ item }: { item: Robot }) => (
+    <RobotListItem
+      robot={item}
+      onDelete={handleDeleteRobot}
+    />
+  ), [handleDeleteRobot]);
+
+  const renderEmptyState = () => (
+    <View style={styles.emptyState}>
+      <Ionicons name="hardware-chip-outline" size={80} color="#d1d5db" />
+      <Text style={styles.emptyTitle}>Aucun robot</Text>
+      <Text style={styles.emptySubtitle}>
+        Commencez par créer votre premier robot !
+      </Text>
+      <TouchableOpacity
+        style={styles.emptyButton}
+        onPress={handleCreateRobot}
+      >
+        <Ionicons name="add-circle" size={20} color="#ffffff" />
+        <Text style={styles.emptyButtonText}>Créer un robot</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  const renderHeader = () => (
+    <View style={styles.header}>
+      <Text style={styles.headerTitle}>Mes Robots</Text>
+      <Text style={styles.headerSubtitle}>
+        {robots.length} robot{robots.length !== 1 ? 's' : ''}
+      </Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={robots}
+        renderItem={renderRobotItem}
+        keyExtractor={(item) => item.id}
+        ListHeaderComponent={renderHeader}
+        ListEmptyComponent={renderEmptyState}
+        contentContainerStyle={[
+          styles.listContent,
+          robots.length === 0 && styles.listContentEmpty
+        ]}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={false}
+            onRefresh={() => {
+              // Les données sont déjà synchronisées via Zustand
+              // Ici on pourrait ajouter un sync avec un serveur
+            }}
+            tintColor="#3b82f6"
+          />
+        }
+      />
+
+      {/* Floating Action Button */}
+      {robots.length > 0 && (
+        <TouchableOpacity
+          style={styles.fab}
+          onPress={handleCreateRobot}
+          accessibilityLabel="Créer un nouveau robot"
+          accessibilityRole="button"
+        >
+          <Ionicons name="add" size={28} color="#ffffff" />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f9fafb',
+  },
+  listContent: {
+    paddingBottom: 100, // Space for FAB
+  },
+  listContentEmpty: {
+    flex: 1,
+  },
+  header: {
+    padding: 20,
+    paddingBottom: 16,
+    backgroundColor: '#f9fafb',
+  },
+  headerTitle: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  headerSubtitle: {
+    fontSize: 16,
+    color: '#6b7280',
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  emptyTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#374151',
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  emptySubtitle: {
+    fontSize: 16,
+    color: '#6b7280',
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: 32,
+  },
+  emptyButton: {
+    backgroundColor: '#3b82f6',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 25,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  emptyButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: 30,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: '#3b82f6',
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 4,
+    },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+    elevation: 8,
+  },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,37 +1,14 @@
 import { Redirect } from "expo-router";
-import { useEffect, useState } from "react";
-import { getLastRoute } from "../hooks/use-route-persistence";
+import { NavigationRestorer } from "../components/navigation-restorer";
 
 /**
- * Point d’entrée : choisit la route de départ.
- * - Si une dernière route existe, on y va
- * - Sinon on va vers /home
- * On renvoie null pendant le chargement pour éviter tout flash.
+ * Point d'entrée : utilise NavigationRestorer pour restaurer la stack complète
+ * au lieu d'une simple redirection
  */
 export default function Index() {
-  const [targetRoute, setTargetRoute] = useState<string | null>(null);
-
-  useEffect(() => {
-    let mounted = true;
-
-    (async () => {
-      const saved = await getLastRoute();
-      if (!mounted) return;
-
-      // Fallback propre vers /home
-      setTargetRoute(saved || "/(main)/(tabs)/home");
-    })();
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  if (!targetRoute) {
-    // Évite d'afficher quoi que ce soit avant d'avoir la route cible
-    return null;
-  }
-
-  return <Redirect href={targetRoute as any} />;
-  // return <Redirect href="/(main)/(tabs)/home" />;
+  return (
+    <NavigationRestorer>
+      <Redirect href="/(main)/(tabs)/home" />
+    </NavigationRestorer>
+  );
 }

--- a/components/navigation-restorer.tsx
+++ b/components/navigation-restorer.tsx
@@ -1,0 +1,85 @@
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { getLastRoute, getNavigationStack } from '../hooks/use-route-persistence';
+
+interface NavigationRestorerProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Composant qui restaure la navigation avec la stack complète
+ * au lieu d'une simple redirection
+ */
+export function NavigationRestorer({ children }: NavigationRestorerProps) {
+  const router = useRouter();
+  const [isRestoring, setIsRestoring] = useState(true);
+
+  useEffect(() => {
+    const restoreNavigation = async () => {
+      try {
+        const lastRoute = await getLastRoute();
+        const navigationStack = await getNavigationStack();
+
+        if (lastRoute && navigationStack && navigationStack.length > 1) {
+          console.log('🔄 Restauration de la navigation avec stack...');
+          console.log('📚 Stack complète:', navigationStack);
+          
+          // Pour les formulaires, utiliser une approche simplifiée
+          if (lastRoute.includes('/tp3-forms/')) {
+            // D'abord aller à l'index des formulaires
+            router.replace('/(main)/(tabs)/tp3-forms' as any);
+            
+            // Puis naviguer vers le formulaire spécifique après un délai
+            setTimeout(() => {
+              router.push(lastRoute as any);
+            }, 100);
+          } else {
+            // Pour les autres routes, navigation séquentielle
+            for (let i = 0; i < navigationStack.length - 1; i++) {
+              const route = navigationStack[i];
+              console.log(`📍 Navigation vers: ${route}`);
+              
+              if (i === 0) {
+                router.replace(route as any);
+              } else {
+                router.push(route as any);
+              }
+              
+              await new Promise(resolve => setTimeout(resolve, 50));
+            }
+            
+            const finalRoute = navigationStack[navigationStack.length - 1];
+            console.log(`🎯 Navigation finale vers: ${finalRoute}`);
+            router.push(finalRoute as any);
+          }
+          
+        } else if (lastRoute) {
+          // Fallback : navigation simple si pas de stack
+          console.log('🔄 Navigation simple vers:', lastRoute);
+          router.replace(lastRoute as any);
+        } else {
+          // Aucune route sauvegardée : aller à l'accueil
+          console.log('🏠 Aucune route sauvegardée, navigation vers l\'accueil');
+          router.replace('/(main)/(tabs)/home' as any);
+        }
+      } catch (error) {
+        console.log('❌ Erreur lors de la restauration de navigation:', error);
+        router.replace('/(main)/(tabs)/home' as any);
+      } finally {
+        setIsRestoring(false);
+      }
+    };
+
+    // Délai pour laisser le temps à l'app de se monter
+    const timer = setTimeout(restoreNavigation, 100);
+    
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  // Afficher les enfants seulement après la restauration
+  if (isRestoring) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/components/robots/RobotForm.tsx
+++ b/components/robots/RobotForm.tsx
@@ -1,0 +1,316 @@
+import { Ionicons } from '@expo/vector-icons';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as Haptics from 'expo-haptics';
+import React, { useRef } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import {
+    Alert,
+    KeyboardAvoidingView,
+    Platform,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View
+} from 'react-native';
+import type { RobotInput } from '../../validation/robotSchema';
+import { robotSchema } from '../../validation/robotSchema';
+import TypeSelector from './TypeSelector';
+
+interface RobotFormProps {
+  initialValues?: Partial<RobotInput>;
+  onSubmit: (data: RobotInput) => Promise<{ success: boolean; error?: string }>;
+  mode: 'create' | 'edit';
+  isLoading?: boolean;
+}
+
+export default function RobotForm({ 
+  initialValues, 
+  onSubmit, 
+  mode, 
+  isLoading = false 
+}: RobotFormProps) {
+  const labelRef = useRef<TextInput>(null);
+  const yearRef = useRef<TextInput>(null);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+    reset,
+  } = useForm<RobotInput>({
+    resolver: zodResolver(robotSchema),
+    defaultValues: {
+      name: initialValues?.name || '',
+      label: initialValues?.label || '',
+      year: initialValues?.year || new Date().getFullYear(),
+      type: initialValues?.type || 'industrial',
+    },
+    mode: 'onChange',
+  });
+
+  const onSubmitForm = async (data: RobotInput) => {
+    try {
+      const result = await onSubmit(data);
+      
+      if (result.success) {
+        // Success haptic feedback
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        
+        if (mode === 'create') {
+          reset(); // Reset form after successful creation
+        }
+      } else {
+        // Error haptic feedback
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        
+        // Show error alert
+        Alert.alert(
+          'Erreur',
+          result.error || 'Une erreur est survenue',
+          [{ text: 'OK', style: 'default' }]
+        );
+      }
+    } catch (error) {
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      Alert.alert(
+        'Erreur',
+        'Une erreur inattendue est survenue',
+        [{ text: 'OK', style: 'default' }]
+      );
+    }
+  };
+
+  const isSubmitDisabled = !isValid || isLoading || (mode === 'edit' && !isDirty);
+
+  return (
+    <KeyboardAvoidingView 
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
+    >
+      <ScrollView 
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Name Field */}
+        <View style={styles.fieldContainer}>
+          <Text style={styles.label}>Nom du robot *</Text>
+          <Controller
+            control={control}
+            name="name"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <TextInput
+                style={[
+                  styles.input,
+                  errors.name && styles.inputError
+                ]}
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+                placeholder="Ex: R2-D2, WALL-E..."
+                placeholderTextColor="#9ca3af"
+                returnKeyType="next"
+                onSubmitEditing={() => labelRef.current?.focus()}
+                maxLength={50}
+                autoCapitalize="words"
+                autoCorrect={false}
+              />
+            )}
+          />
+          {errors.name && (
+            <Text style={styles.errorText}>{errors.name.message}</Text>
+          )}
+        </View>
+
+        {/* Label Field */}
+        <View style={styles.fieldContainer}>
+          <Text style={styles.label}>Libellé *</Text>
+          <Controller
+            control={control}
+            name="label"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <TextInput
+                ref={labelRef}
+                style={[
+                  styles.input,
+                  errors.label && styles.inputError
+                ]}
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+                placeholder="Description courte du robot..."
+                placeholderTextColor="#9ca3af"
+                returnKeyType="next"
+                onSubmitEditing={() => yearRef.current?.focus()}
+                maxLength={100}
+                autoCapitalize="sentences"
+                multiline={false}
+              />
+            )}
+          />
+          {errors.label && (
+            <Text style={styles.errorText}>{errors.label.message}</Text>
+          )}
+        </View>
+
+        {/* Year Field */}
+        <View style={styles.fieldContainer}>
+          <Text style={styles.label}>Année de création *</Text>
+          <Controller
+            control={control}
+            name="year"
+            render={({ field: { onChange, onBlur, value } }) => (
+              <TextInput
+                ref={yearRef}
+                style={[
+                  styles.input,
+                  errors.year && styles.inputError
+                ]}
+                value={value?.toString() || ''}
+                onChangeText={(text) => {
+                  const numValue = parseInt(text, 10);
+                  onChange(isNaN(numValue) ? undefined : numValue);
+                }}
+                onBlur={onBlur}
+                placeholder="Ex: 2020"
+                placeholderTextColor="#9ca3af"
+                keyboardType="numeric"
+                returnKeyType="done"
+                maxLength={4}
+              />
+            )}
+          />
+          {errors.year && (
+            <Text style={styles.errorText}>{errors.year.message}</Text>
+          )}
+        </View>
+
+        {/* Type Field */}
+        <View style={styles.fieldContainer}>
+          <Text style={styles.label}>Type de robot *</Text>
+          <Controller
+            control={control}
+            name="type"
+            render={({ field: { onChange, value } }) => (
+              <TypeSelector
+                value={value}
+                onChange={onChange}
+                hasError={!!errors.type}
+              />
+            )}
+          />
+          {errors.type && (
+            <Text style={styles.errorText}>{errors.type.message}</Text>
+          )}
+        </View>
+
+        {/* Submit Button */}
+        <TouchableOpacity
+          style={[
+            styles.submitButton,
+            isSubmitDisabled && styles.submitButtonDisabled
+          ]}
+          onPress={handleSubmit(onSubmitForm)}
+          disabled={isSubmitDisabled}
+        >
+          <Ionicons
+            name={mode === 'create' ? 'add-circle' : 'save'}
+            size={20}
+            color={isSubmitDisabled ? '#9ca3af' : '#ffffff'}
+            style={styles.submitIcon}
+          />
+          <Text style={[
+            styles.submitButtonText,
+            isSubmitDisabled && styles.submitButtonTextDisabled
+          ]}>
+            {isLoading 
+              ? 'En cours...' 
+              : mode === 'create' 
+                ? 'Créer le robot' 
+                : 'Mettre à jour'
+            }
+          </Text>
+        </TouchableOpacity>
+
+        {/* Form Info */}
+        <Text style={styles.infoText}>
+          * Champs obligatoires
+        </Text>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f9fafb',
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  fieldContainer: {
+    marginBottom: 20,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#374151',
+    marginBottom: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+    backgroundColor: '#ffffff',
+    color: '#111827',
+  },
+  inputError: {
+    borderColor: '#ef4444',
+  },
+  errorText: {
+    color: '#ef4444',
+    fontSize: 14,
+    marginTop: 4,
+  },
+  submitButton: {
+    backgroundColor: '#3b82f6',
+    borderRadius: 8,
+    paddingVertical: 16,
+    paddingHorizontal: 24,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 16,
+  },
+  submitButtonDisabled: {
+    backgroundColor: '#e5e7eb',
+  },
+  submitIcon: {
+    marginRight: 8,
+  },
+  submitButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  submitButtonTextDisabled: {
+    color: '#9ca3af',
+  },
+  infoText: {
+    color: '#6b7280',
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 16,
+  },
+});

--- a/components/robots/RobotListItem.tsx
+++ b/components/robots/RobotListItem.tsx
@@ -1,0 +1,231 @@
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { useRouter } from 'expo-router';
+import React from 'react';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { Robot } from '../../validation/robotSchema';
+import { robotTypeOptions } from '../../validation/robotSchema';
+
+interface RobotListItemProps {
+  robot: Robot;
+  onDelete: (id: string) => void;
+}
+
+export default function RobotListItem({ robot, onDelete }: RobotListItemProps) {
+  const router = useRouter();
+
+  const getTypeLabel = (type: string) => {
+    const option = robotTypeOptions.find(opt => opt.value === type);
+    return option?.label || type;
+  };
+
+  const handleEdit = async () => {
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    router.push(`/tp4-robots/edit/${robot.id}` as any);
+  };
+
+  const handleDelete = async () => {
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    
+    Alert.alert(
+      'Supprimer le robot',
+      `Êtes-vous sûr de vouloir supprimer "${robot.name}" ?\n\nCette action est irréversible.`,
+      [
+        {
+          text: 'Annuler',
+          style: 'cancel',
+        },
+        {
+          text: 'Supprimer',
+          style: 'destructive',
+          onPress: async () => {
+            await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            onDelete(robot.id);
+          },
+        },
+      ]
+    );
+  };
+
+  const getTypeIcon = (type: string) => {
+    switch (type) {
+      case 'industrial':
+        return 'construct-outline';
+      case 'service':
+        return 'people-outline';
+      case 'medical':
+        return 'medical-outline';
+      case 'educational':
+        return 'school-outline';
+      default:
+        return 'hardware-chip-outline';
+    }
+  };
+
+  const getTypeColor = (type: string) => {
+    switch (type) {
+      case 'industrial':
+        return '#f59e0b';
+      case 'service':
+        return '#3b82f6';
+      case 'medical':
+        return '#ef4444';
+      case 'educational':
+        return '#10b981';
+      default:
+        return '#6b7280';
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        {/* Robot Info */}
+        <View style={styles.info}>
+          <View style={styles.header}>
+            <Text style={styles.name}>{robot.name}</Text>
+            <View style={[
+              styles.typeBadge,
+              { backgroundColor: `${getTypeColor(robot.type)}20` }
+            ]}>
+              <Ionicons
+                name={getTypeIcon(robot.type) as any}
+                size={14}
+                color={getTypeColor(robot.type)}
+                style={styles.typeIcon}
+              />
+              <Text style={[styles.typeText, { color: getTypeColor(robot.type) }]}>
+                {getTypeLabel(robot.type)}
+              </Text>
+            </View>
+          </View>
+          
+          <Text style={styles.label} numberOfLines={2}>
+            {robot.label}
+          </Text>
+          
+          <View style={styles.footer}>
+            <Text style={styles.year}>Année: {robot.year}</Text>
+            <Text style={styles.dates}>
+              Créé le {robot.createdAt.toLocaleDateString('fr-FR')}
+            </Text>
+          </View>
+        </View>
+
+        {/* Actions */}
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={[styles.actionButton, styles.editButton]}
+            onPress={handleEdit}
+            accessibilityLabel={`Modifier ${robot.name}`}
+            accessibilityRole="button"
+          >
+            <Ionicons name="pencil" size={18} color="#3b82f6" />
+          </TouchableOpacity>
+          
+          <TouchableOpacity
+            style={[styles.actionButton, styles.deleteButton]}
+            onPress={handleDelete}
+            accessibilityLabel={`Supprimer ${robot.name}`}
+            accessibilityRole="button"
+          >
+            <Ionicons name="trash" size={18} color="#ef4444" />
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#ffffff',
+    marginHorizontal: 16,
+    marginVertical: 6,
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.1,
+    shadowRadius: 3.84,
+    elevation: 5,
+  },
+  content: {
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+  info: {
+    flex: 1,
+    marginRight: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  name: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
+    flex: 1,
+    marginRight: 8,
+  },
+  typeBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  typeIcon: {
+    marginRight: 4,
+  },
+  typeText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  label: {
+    fontSize: 14,
+    color: '#6b7280',
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  year: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#374151',
+  },
+  dates: {
+    fontSize: 12,
+    color: '#9ca3af',
+  },
+  actions: {
+    flexDirection: 'column',
+    gap: 8,
+  },
+  actionButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+  },
+  editButton: {
+    backgroundColor: '#eff6ff',
+    borderColor: '#dbeafe',
+  },
+  deleteButton: {
+    backgroundColor: '#fef2f2',
+    borderColor: '#fecaca',
+  },
+});

--- a/components/robots/TypeSelector.tsx
+++ b/components/robots/TypeSelector.tsx
@@ -1,0 +1,93 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import {
+    ActionSheetIOS,
+    Alert,
+    Platform,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+} from 'react-native';
+import { robotTypeOptions } from '../../validation/robotSchema';
+
+interface TypeSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+  hasError?: boolean;
+}
+
+export default function TypeSelector({ value, onChange, hasError }: TypeSelectorProps) {
+  const selectedOption = robotTypeOptions.find(opt => opt.value === value);
+  
+  const handlePress = () => {
+    if (Platform.OS === 'ios') {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          options: ['Annuler', ...robotTypeOptions.map(opt => opt.label)],
+          cancelButtonIndex: 0,
+          title: 'Choisir le type de robot',
+        },
+        (buttonIndex) => {
+          if (buttonIndex > 0) {
+            const selectedType = robotTypeOptions[buttonIndex - 1];
+            onChange(selectedType.value);
+          }
+        }
+      );
+    } else {
+      // Pour Android
+      Alert.alert(
+        'Type de robot',
+        'Choisissez le type de robot',
+        robotTypeOptions.map(opt => ({
+          text: opt.label,
+          onPress: () => onChange(opt.value)
+        })).concat([{ text: 'Annuler', style: 'cancel' }])
+      );
+    }
+  };
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.typeSelector,
+        hasError && styles.inputError
+      ]}
+      onPress={handlePress}
+    >
+      <Text style={[
+        styles.typeSelectorText,
+        !selectedOption && styles.placeholder
+      ]}>
+        {selectedOption ? selectedOption.label : 'Sélectionner un type...'}
+      </Text>
+      <Ionicons name="chevron-down" size={20} color="#6b7280" />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  typeSelector: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: 50,
+  },
+  inputError: {
+    borderColor: '#ef4444',
+  },
+  typeSelectorText: {
+    fontSize: 16,
+    color: '#111827',
+    flex: 1,
+  },
+  placeholder: {
+    color: '#9ca3af',
+  },
+});

--- a/hooks/use-route-persistence.ts
+++ b/hooks/use-route-persistence.ts
@@ -3,9 +3,10 @@ import { usePathname } from 'expo-router';
 import { useEffect } from 'react';
 
 const LAST_ROUTE_KEY = 'lastRoute';
+const NAVIGATION_STACK_KEY = 'navigationStack';
 
 /**
- * Hook pour sauvegarder automatiquement la route courante
+ * Hook pour sauvegarder automatiquement la route courante et construire la stack de navigation
  */
 export function useRoutePersistence() {
   const pathname = usePathname();
@@ -16,7 +17,13 @@ export function useRoutePersistence() {
         // Ne pas sauvegarder la route racine "/"
         if (pathname && pathname !== '/') {
           await AsyncStorage.setItem(LAST_ROUTE_KEY, pathname);
+          
+          // Construire et sauvegarder la stack de navigation logique
+          const navigationStack = buildNavigationStack(pathname);
+          await AsyncStorage.setItem(NAVIGATION_STACK_KEY, JSON.stringify(navigationStack));
+          
           // console.log(`💾 Route sauvegardée automatiquement: ${pathname}`);
+          // console.log(`📚 Stack de navigation: ${JSON.stringify(navigationStack)}`);
         }
       } catch (error) {
         console.log('❌ Erreur sauvegarde route:', error);
@@ -25,6 +32,37 @@ export function useRoutePersistence() {
 
     saveCurrentRoute();
   }, [pathname]);
+}
+
+/**
+ * Construit une stack de navigation logique basée sur la route actuelle
+ */
+function buildNavigationStack(pathname: string): string[] {
+  const stack: string[] = [];
+  
+  // Toujours commencer par l'accueil
+  stack.push('/(main)/(tabs)/home');
+  
+  // Analyser le chemin pour construire la stack logique
+  if (pathname.includes('/tp3-forms')) {
+    // Si on est dans tp3-forms, ajouter l'index des formulaires
+    stack.push('/(main)/(tabs)/tp3-forms');
+    
+    // Si on est sur un formulaire spécifique, l'ajouter
+    if (pathname.includes('/formik')) {
+      stack.push('/(main)/(tabs)/tp3-forms/formik');
+    } else if (pathname.includes('/rhf')) {
+      stack.push('/(main)/(tabs)/tp3-forms/rhf');
+    }
+  } else if (pathname.includes('/detail/')) {
+    // Pour les détails, venir de l'accueil
+    stack.push(pathname);
+  } else if (pathname !== '/(main)/(tabs)/home') {
+    // Pour les autres routes, les ajouter directement
+    stack.push(pathname);
+  }
+  
+  return stack;
 }
 
 /**
@@ -42,12 +80,31 @@ export async function getLastRoute(): Promise<string | null> {
 }
 
 /**
+ * Utilitaire pour récupérer la stack de navigation sauvegardée
+ */
+export async function getNavigationStack(): Promise<string[] | null> {
+  try {
+    const stackJson = await AsyncStorage.getItem(NAVIGATION_STACK_KEY);
+    if (stackJson) {
+      const stack = JSON.parse(stackJson) as string[];
+      console.log('📚 Stack de navigation récupérée:', stack);
+      return stack;
+    }
+    return null;
+  } catch (error) {
+    console.log('❌ Erreur récupération stack de navigation:', error);
+    return null;
+  }
+}
+
+/**
  * Utilitaire pour effacer la route sauvegardée
  */
 export async function clearSavedRoute(): Promise<void> {
   try {
     await AsyncStorage.removeItem(LAST_ROUTE_KEY);
-    console.log('💾 Route effacée du storage');
+    await AsyncStorage.removeItem(NAVIGATION_STACK_KEY);
+    console.log('💾 Route et stack effacées du storage');
   } catch (error) {
     console.log('❌ Erreur effacement route:', error);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/vector-icons": "^15.0.2",
         "@hookform/resolvers": "^5.2.2",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-picker/picker": "^2.11.2",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -38,7 +39,8 @@
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
         "yup": "^1.7.0",
-        "zod": "^4.1.8"
+        "zod": "^4.1.8",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -3009,6 +3011,18 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.11.2.tgz",
+      "integrity": "sha512-2zyFdW4jgHjF+NeuDZ4nl3hJ+8suey69bI3yljqhNyowfklW2NwNrdDUaJ2iwtPCpk2pt7834aPF8TI6iyZRhA==",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -12579,6 +12593,34 @@
       "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-picker/picker": "^2.11.2",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
@@ -41,7 +42,8 @@
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
     "yup": "^1.7.0",
-    "zod": "^4.1.8"
+    "zod": "^4.1.8",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/store/robotsStore.ts
+++ b/store/robotsStore.ts
@@ -1,0 +1,197 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import type { Robot, RobotInput } from '../validation/robotSchema';
+
+interface RobotsState {
+  robots: Robot[];
+  selectedId?: string;
+}
+
+interface RobotsActions {
+  // CRUD Operations
+  create: (robotInput: RobotInput) => Promise<{ success: boolean; error?: string; robot?: Robot }>;
+  update: (id: string, robotInput: RobotInput) => Promise<{ success: boolean; error?: string; robot?: Robot }>;
+  remove: (id: string) => boolean;
+  getById: (id: string) => Robot | undefined;
+  
+  // Selection
+  setSelectedId: (id?: string) => void;
+  
+  // Utility
+  isNameUnique: (name: string, excludeId?: string) => boolean;
+  getRobotsSorted: () => Robot[];
+}
+
+type RobotsStore = RobotsState & RobotsActions;
+
+/**
+ * Generate a simple UUID v4
+ */
+function generateId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    const r = Math.random() * 16 | 0;
+    const v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
+
+export const useRobotsStore = create<RobotsStore>()(
+  persist(
+    (set, get) => ({
+      // Initial State
+      robots: [],
+      selectedId: undefined,
+
+      // CRUD Operations
+      create: async (robotInput: RobotInput) => {
+        const state = get();
+        
+        // Check name uniqueness
+        if (!state.isNameUnique(robotInput.name)) {
+          return {
+            success: false,
+            error: `Un robot avec le nom "${robotInput.name}" existe déjà`,
+          };
+        }
+
+        const now = new Date();
+        const newRobot: Robot = {
+          id: generateId(),
+          ...robotInput,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        set((state) => ({
+          robots: [...state.robots, newRobot],
+        }));
+
+        console.log('🤖 Robot créé:', newRobot.name);
+        return { success: true, robot: newRobot };
+      },
+
+      update: async (id: string, robotInput: RobotInput) => {
+        const state = get();
+        const existingRobot = state.getById(id);
+        
+        if (!existingRobot) {
+          return {
+            success: false,
+            error: 'Robot non trouvé',
+          };
+        }
+
+        // Check name uniqueness (exclude current robot)
+        if (!state.isNameUnique(robotInput.name, id)) {
+          return {
+            success: false,
+            error: `Un autre robot avec le nom "${robotInput.name}" existe déjà`,
+          };
+        }
+
+        const updatedRobot: Robot = {
+          ...existingRobot,
+          ...robotInput,
+          updatedAt: new Date(),
+        };
+
+        set((state) => ({
+          robots: state.robots.map((robot) =>
+            robot.id === id ? updatedRobot : robot
+          ),
+        }));
+
+        console.log('🤖 Robot mis à jour:', updatedRobot.name);
+        return { success: true, robot: updatedRobot };
+      },
+
+      remove: (id: string) => {
+        const state = get();
+        const robot = state.getById(id);
+        
+        if (!robot) {
+          return false;
+        }
+
+        set((state) => ({
+          robots: state.robots.filter((r) => r.id !== id),
+          selectedId: state.selectedId === id ? undefined : state.selectedId,
+        }));
+
+        console.log('🤖 Robot supprimé:', robot.name);
+        return true;
+      },
+
+      getById: (id: string) => {
+        return get().robots.find((robot) => robot.id === id);
+      },
+
+      // Selection
+      setSelectedId: (id?: string) => {
+        set({ selectedId: id });
+      },
+
+      // Utility functions
+      isNameUnique: (name: string, excludeId?: string) => {
+        const robots = get().robots;
+        const normalizedName = name.toLowerCase().trim();
+        
+        return !robots.some((robot) => 
+          robot.id !== excludeId && 
+          robot.name.toLowerCase().trim() === normalizedName
+        );
+      },
+
+      getRobotsSorted: () => {
+        return get().robots.sort((a, b) => a.name.localeCompare(b.name));
+      },
+    }),
+    {
+      name: 'robots-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+      // Only persist the robots data, not UI state like selectedId
+      partialize: (state) => ({ robots: state.robots }),
+      
+      // Handle date deserialization
+      onRehydrateStorage: () => (state) => {
+        if (state?.robots) {
+          state.robots = state.robots.map((robot: any) => ({
+            ...robot,
+            createdAt: new Date(robot.createdAt),
+            updatedAt: new Date(robot.updatedAt),
+          }));
+        }
+      },
+    }
+  )
+);
+
+// Selectors for better performance
+export const useRobots = () => useRobotsStore((state) => state.robots);
+export const useRobotsSorted = () => useRobotsStore((state) => state.getRobotsSorted());
+export const useSelectedRobot = () => {
+  const selectedId = useRobotsStore((state) => state.selectedId);
+  const getById = useRobotsStore((state) => state.getById);
+  return selectedId ? getById(selectedId) : undefined;
+};
+
+// Actions selectors - Individual hooks to prevent object recreation
+export const useCreateRobot = () => useRobotsStore((state) => state.create);
+export const useUpdateRobot = () => useRobotsStore((state) => state.update);
+export const useRemoveRobot = () => useRobotsStore((state) => state.remove);
+export const useGetRobotById = () => useRobotsStore((state) => state.getById);
+export const useSetSelectedId = () => useRobotsStore((state) => state.setSelectedId);
+export const useIsNameUnique = () => useRobotsStore((state) => state.isNameUnique);
+
+// Combined actions hook with proper memoization
+export const useRobotsActions = () => {
+  const create = useRobotsStore((state) => state.create);
+  const update = useRobotsStore((state) => state.update);
+  const remove = useRobotsStore((state) => state.remove);
+  const getById = useRobotsStore((state) => state.getById);
+  const setSelectedId = useRobotsStore((state) => state.setSelectedId);
+  const isNameUnique = useRobotsStore((state) => state.isNameUnique);
+  
+  return { create, update, remove, getById, setSelectedId, isNameUnique };
+};

--- a/validation/robotSchema.ts
+++ b/validation/robotSchema.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+export const RobotType = {
+  INDUSTRIAL: 'industrial',
+  SERVICE: 'service',
+  MEDICAL: 'medical',
+  EDUCATIONAL: 'educational',
+  OTHER: 'other',
+} as const;
+
+export type RobotType = typeof RobotType[keyof typeof RobotType];
+
+export const robotTypeOptions = [
+  { label: 'Industriel', value: RobotType.INDUSTRIAL },
+  { label: 'Service', value: RobotType.SERVICE },
+  { label: 'Médical', value: RobotType.MEDICAL },
+  { label: 'Éducatif', value: RobotType.EDUCATIONAL },
+  { label: 'Autre', value: RobotType.OTHER },
+] as const;
+
+const currentYear = new Date().getFullYear();
+
+export const robotSchema = z.object({
+  name: z
+    .string()
+    .min(2, 'Le nom doit contenir au moins 2 caractères')
+    .max(50, 'Le nom ne peut pas dépasser 50 caractères')
+    .trim(),
+  
+  label: z
+    .string()
+    .min(3, 'Le libellé doit contenir au moins 3 caractères')
+    .max(100, 'Le libellé ne peut pas dépasser 100 caractères')
+    .trim(),
+  
+  year: z
+    .number({
+      required_error: 'L\'année est requise',
+      invalid_type_error: 'L\'année doit être un nombre',
+    })
+    .int('L\'année doit être un nombre entier')
+    .min(1950, 'L\'année doit être supérieure ou égale à 1950')
+    .max(currentYear, `L'année ne peut pas être supérieure à ${currentYear}`),
+  
+  type: z.enum([
+    RobotType.INDUSTRIAL,
+    RobotType.SERVICE,
+    RobotType.MEDICAL,
+    RobotType.EDUCATIONAL,
+    RobotType.OTHER,
+  ], {
+    required_error: 'Le type de robot est requis',
+    invalid_type_error: 'Type de robot invalide',
+  }),
+});
+
+export type RobotInput = z.infer<typeof robotSchema>;
+
+export interface Robot extends RobotInput {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export default robotSchema;


### PR DESCRIPTION
…t screens

Architecture:
- Add /(main)/(tabs)/tp4-robots with Stack layout and dedicated routes
- Create list, create, and edit screens with proper native headers
- Reusable components: components/robots/RobotForm, RobotListItem, TypeSelector

Store (Zustand):
- Global robots store with CRUD actions (create, update, remove, getById)
- Persistence with AsyncStorage (persist middleware) and Date deserialization on rehydrate
- Optimized selectors (useRobots, useRobotsSorted, actions hooks) to minimize re-renders

Validation & Forms:
- React Hook Form + Zod schema (validation/robotSchema.ts)
- Single RobotForm reused for create and edit modes
- Submit disabled when invalid, real-time validation errors, focus chain and reset on success

UI/UX:
- Sorted list with badges by type, quick edit/delete actions (with confirmation)
- Empty state with CTA, Floating Action Button for creation
- KeyboardAvoidingView, native picker for type, and haptic feedback

Navigation:
- Expo Router routes: /tp4-robots, /tp4-robots/create, /tp4-robots/edit/[id]
- Seamless back navigation via native headers and gestures

Technical:
- Add navigation-restorer and route persistence improvements
- Keep store free of UI logic; immutable updates and granular selectors

Documentation:
- Update README: TP4 section, routes table, deep links tests, condensed persistence section